### PR TITLE
Fix ESLint errors: setState called directly in useEffect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,9 @@ function App() {
   const selectedProjectId = useProjectsStore((s) => s.selectedProjectId)
 
   const renderDetailContent = () => {
-    if (selectedToolId) return <ToolDetail />
+    if (selectedToolId) return <ToolDetail key={selectedToolId} />
     if (selectedProjectId === 'new') return <CreateProjectDetail />
-    if (selectedProjectId) return <ProjectDetail />
+    if (selectedProjectId) return <ProjectDetail key={selectedProjectId} />
     return null
   }
 

--- a/src/components/detail/ProjectDetail.tsx
+++ b/src/components/detail/ProjectDetail.tsx
@@ -225,13 +225,6 @@ export function ProjectDetail() {
   );
   const [localPriority, setLocalPriority] = useState(initialPriority);
 
-  // Sync local priority when the selected project changes
-  const projectIdForSync = selectedProject?.id;
-  useMemo(() => {
-    setLocalPriority(initialPriority);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectIdForSync]);
-
   const relatedData = useMemo(() => {
     if (!selectedProjectId) return null;
     return { projectId: selectedProjectId };

--- a/src/components/detail/ToolDetail.tsx
+++ b/src/components/detail/ToolDetail.tsx
@@ -57,13 +57,6 @@ export function ToolDetail() {
   const [formData, setFormData] = useState<ToolFormData>(initialFormData);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  // Sync form when selected tool changes (use key pattern via useMemo)
-  const toolVersion = selectedTool?.id ?? 'new';
-  useMemo(() => {
-    setFormData(initialFormData);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toolVersion]);
-
   const handleSave = async () => {
     if (isNew) {
       await createTool(formData as Parameters<typeof createTool>[0]);


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

Fixes the `react-hooks/set-state-in-effect` ESLint violations in `ProjectDetail` and `ToolDetail` by adopting the React key pattern:

- **`src/App.tsx`** — Added `key={selectedToolId}` and `key={selectedProjectId}` to `<ToolDetail>` and `<ProjectDetail>`, so React remounts the component when the selected item changes
- **`src/components/detail/ProjectDetail.tsx`** — Removed the `useMemo` block that called `setLocalPriority(initialPriority)` to sync state on project change (now handled by remount)
- **`src/components/detail/ToolDetail.tsx`** — Removed the `useMemo` block that called `setFormData(initialFormData)` to sync state on tool change (now handled by remount)

This eliminates cascading re-renders from setState-in-hooks and removes the `eslint-disable` comments.

## Verification

- ESLint passes cleanly across the entire `src/` directory
- TypeScript compiles with zero errors

Resolves [ENG-1](https://linear.app/alecv/issue/ENG-1/fix-eslint-errors-setstate-called-directly-in-useeffect)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
