### PR TITLE
Add error boundary and 404 page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tmp-9z4sugsr0m",
+  "name": "muninn",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tmp-9z4sugsr0m",
+      "name": "muninn",
       "version": "0.0.0",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Warning } from '@phosphor-icons/react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex h-screen items-center justify-center bg-surface text-normal">
+        <div className="flex flex-col items-center gap-6 px-6 text-center max-w-md">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-error/10">
+            <Warning size={32} className="text-error" weight="duotone" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <h1 className="text-xl font-semibold text-high">Something went wrong</h1>
+            <p className="text-sm text-low">
+              An unexpected error occurred. You can try again or reload the page.
+            </p>
+          </div>
+          {this.state.error && (
+            <pre className="w-full rounded-lg bg-muted px-4 py-3 text-left text-xs text-low font-mono overflow-auto max-h-32">
+              {this.state.error.message}
+            </pre>
+          )}
+          <div className="flex gap-3">
+            <button
+              onClick={this.handleRetry}
+              className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover transition-colors"
+            >
+              Try again
+            </button>
+            <button
+              onClick={() => window.location.reload()}
+              className="rounded-lg bg-elevated px-4 py-2 text-sm font-medium text-normal hover:bg-muted transition-colors"
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,24 +1,29 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Route, Routes } from 'react-router'
+import { ErrorBoundary } from './components/ui/ErrorBoundary'
 import App from './App'
 import BoardPage from './pages/BoardPage'
 import ToolsPage from './pages/ToolsPage'
 import AgentsPage from './pages/AgentsPage'
 import SettingsPage from './pages/SettingsPage'
+import NotFoundPage from './pages/NotFoundPage'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />}>
-          <Route index element={<BoardPage />} />
-          <Route path="tools" element={<ToolsPage />} />
-          <Route path="agents" element={<AgentsPage />} />
-          <Route path="settings" element={<SettingsPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />}>
+            <Route index element={<BoardPage />} />
+            <Route path="tools" element={<ToolsPage />} />
+            <Route path="agents" element={<AgentsPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,8 +20,8 @@ createRoot(document.getElementById('root')!).render(
             <Route path="tools" element={<ToolsPage />} />
             <Route path="agents" element={<AgentsPage />} />
             <Route path="settings" element={<SettingsPage />} />
-            <Route path="*" element={<NotFoundPage />} />
           </Route>
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </BrowserRouter>
     </ErrorBoundary>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router';
+import { MagnifyingGlass } from '@phosphor-icons/react';
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex flex-col items-center gap-6 px-6 text-center max-w-md">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand/10">
+          <MagnifyingGlass size={32} className="text-brand" weight="duotone" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <h1 className="text-xl font-semibold text-high">Page not found</h1>
+          <p className="text-sm text-low">
+            The page you're looking for doesn't exist or has been moved.
+          </p>
+        </div>
+        <Link
+          to="/"
+          className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover transition-colors"
+        >
+          Back to board
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Add a top-level `ErrorBoundary` class component that catches unhandled React errors and renders a fallback UI with "Try again" and "Reload page" buttons, preventing white-screen crashes
- Add a `NotFoundPage` component rendered via a `*` catch-all route so invalid paths show a proper 404 message with a link back to the board
- Wrap the entire app with the ErrorBoundary in `main.tsx` and register the catch-all route alongside existing routes

## Test plan

- [ ] Navigate to an invalid path (e.g., `/nonexistent`) and verify the 404 page renders with "Page not found" and a "Back to board" link
- [ ] Click "Back to board" on the 404 page and verify it navigates to the kanban board
- [ ] Temporarily introduce a runtime error in a component and verify the error boundary catches it, showing the fallback UI
- [ ] Click "Try again" on the error fallback and verify the app re-renders
- [ ] Click "Reload page" on the error fallback and verify the page reloads
- [ ] Verify normal navigation between Board, Tools, Agents, and Settings still works

Resolves [ENG-4](https://linear.app/alecv/issue/ENG-4/add-error-boundary-and-404-page)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
