### PR TITLE
Fix missing error handling in form save operations

### DIFF
--- a/src/components/detail/CreateProjectDetail.tsx
+++ b/src/components/detail/CreateProjectDetail.tsx
@@ -26,20 +26,22 @@ export function CreateProjectDetail() {
       .map((t) => t.trim())
       .filter(Boolean);
 
-    const project = await createProject({
-      name: name.trim(),
-      description: description.trim() || null,
-      status,
-      board_status: status,
-      board_position: 0,
-      priority: priority ? Number(priority) : null,
-      tech_stack: tags.length > 0 ? tags : null,
-    });
+    try {
+      const project = await createProject({
+        name: name.trim(),
+        description: description.trim() || null,
+        status,
+        board_status: status,
+        board_position: 0,
+        priority: priority ? Number(priority) : null,
+        tech_stack: tags.length > 0 ? tags : null,
+      });
 
-    setIsSaving(false);
-
-    if (project) {
-      selectProject(project.id);
+      if (project) {
+        selectProject(project.id);
+      }
+    } finally {
+      setIsSaving(false);
     }
   };
 

--- a/src/components/detail/ProjectDetail.tsx
+++ b/src/components/detail/ProjectDetail.tsx
@@ -277,9 +277,11 @@ export function ProjectDetail() {
 
   const handleDelete = useCallback(async () => {
     if (!selectedProject) return;
-    await deleteProject(selectedProject.id);
-    selectProject(null);
-    closePanel();
+    const success = await deleteProject(selectedProject.id);
+    if (success) {
+      selectProject(null);
+      closePanel();
+    }
   }, [selectedProject, deleteProject, selectProject, closePanel]);
 
   if (!selectedProject) {

--- a/src/components/detail/ToolDetail.tsx
+++ b/src/components/detail/ToolDetail.tsx
@@ -56,22 +56,30 @@ export function ToolDetail() {
 
   const [formData, setFormData] = useState<ToolFormData>(initialFormData);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleSave = async () => {
+    setIsSaving(true);
+    let result;
     if (isNew) {
-      await createTool(formData as Parameters<typeof createTool>[0]);
+      result = await createTool(formData as Parameters<typeof createTool>[0]);
     } else if (selectedToolId) {
-      await updateTool(selectedToolId, formData as Parameters<typeof updateTool>[1]);
+      result = await updateTool(selectedToolId, formData as Parameters<typeof updateTool>[1]);
     }
-    selectTool(null);
-    closePanel();
+    setIsSaving(false);
+    if (result) {
+      selectTool(null);
+      closePanel();
+    }
   };
 
   const handleDelete = async () => {
     if (selectedToolId && !isNew) {
-      await deleteTool(selectedToolId);
-      selectTool(null);
-      closePanel();
+      const success = await deleteTool(selectedToolId);
+      if (success) {
+        selectTool(null);
+        closePanel();
+      }
     }
   };
 
@@ -96,7 +104,8 @@ export function ToolDetail() {
         <div className="flex gap-2">
           <button
             onClick={() => void handleSave()}
-            className="p-2 bg-brand text-white rounded-lg hover:bg-brand-hover"
+            disabled={isSaving}
+            className="p-2 bg-brand text-white rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Check size={18} />
           </button>


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

Detail panels now check store return values before closing — if a save or delete fails, the panel stays open so the user sees the error toast and can retry.

- **ProjectDetail.tsx** — `handleDelete` only closes panel on success (checks `deleteProject` return value)
- **ToolDetail.tsx** — `handleSave` and `handleDelete` check return values before closing; adds `isSaving` loading state with disabled button styling
- **CreateProjectDetail.tsx** — wraps `createProject` in `try/finally` to ensure `isSaving` resets even on unexpected errors

The existing `ErrorToast` component already reads store error state, so error feedback is displayed automatically when any store action fails. The fix ensures the UI doesn't dismiss the context the user needs to see the error and retry.

## Test plan

- [ ] Save a project field edit with network disabled — error toast appears, panel stays open
- [ ] Create a new tool with invalid data — form stays open on failure, save button shows loading state
- [ ] Delete a project with network disabled — error toast appears, panel stays open
- [ ] Happy path: all save/create/delete operations still close panel on success

Resolves [ENG-2](https://linear.app/alecv/issue/ENG-2/missing-error-handling-in-form-save-operations)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
