### PR TITLE
Add pagination for agent sessions

### DIFF
--- a/src/components/agents/SessionFeed.tsx
+++ b/src/components/agents/SessionFeed.tsx
@@ -2,15 +2,14 @@ import { SessionCard } from './SessionCard';
 import { useSessionsStore } from '../../store/sessions';
 
 export function SessionFeed() {
-  const { filteredSessions, isLoading } = useSessionsStore();
-  const sessions = filteredSessions();
+  const { sessions, isLoading, isFetchingMore, hasMore, fetchMoreSessions } = useSessionsStore();
 
   const grouped = sessions.reduce((acc, session) => {
-    const date = session.started_at 
-      ? new Date(session.started_at).toLocaleDateString('en-US', { 
-          weekday: 'short', 
-          month: 'short', 
-          day: 'numeric' 
+    const date = session.started_at
+      ? new Date(session.started_at).toLocaleDateString('en-US', {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric'
         })
       : 'Unknown';
     if (!acc[date]) acc[date] = [];
@@ -51,6 +50,18 @@ export function SessionFeed() {
           </div>
         </div>
       ))}
+
+      {hasMore && (
+        <div className="flex justify-center py-4">
+          <button
+            onClick={() => void fetchMoreSessions()}
+            disabled={isFetchingMore}
+            className="px-4 py-2 text-sm rounded-lg border border-border text-low hover:text-normal hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isFetchingMore ? 'Loading...' : 'Load more'}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -3,14 +3,21 @@ import { SessionFeed } from '../components/agents/SessionFeed';
 import { useSessionsStore } from '../store/sessions';
 
 export default function AgentsPage() {
-  const { fetchSessions, sessions, filterInterface, filterMachine, setFilterInterface, setFilterMachine } = useSessionsStore();
+  const {
+    fetchSessions,
+    fetchFilterOptions,
+    availableInterfaces,
+    availableMachines,
+    filterInterface,
+    filterMachine,
+    setFilterInterface,
+    setFilterMachine,
+  } = useSessionsStore();
 
   useEffect(() => {
     void fetchSessions();
-  }, [fetchSessions]);
-
-  const interfaces: string[] = [...new Set(sessions.map((s) => s.interface).filter((value): value is string => Boolean(value)))];
-  const machines: string[] = [...new Set(sessions.map((s) => s.machine).filter((value): value is string => Boolean(value)))];
+    void fetchFilterOptions();
+  }, [fetchSessions, fetchFilterOptions]);
 
   return (
     <div className="h-full flex flex-col">
@@ -23,7 +30,7 @@ export default function AgentsPage() {
             className="bg-muted border border-border rounded-lg px-3 py-1 text-xs text-normal focus:outline-none focus:ring-1 focus:ring-brand"
           >
             <option value="">All</option>
-            {interfaces.map((i) => (
+            {availableInterfaces.map((i) => (
               <option key={i} value={i}>{i}</option>
             ))}
           </select>
@@ -36,7 +43,7 @@ export default function AgentsPage() {
             className="bg-muted border border-border rounded-lg px-3 py-1 text-xs text-normal focus:outline-none focus:ring-1 focus:ring-brand"
           >
             <option value="">All</option>
-            {machines.map((m) => (
+            {availableMachines.map((m) => (
               <option key={m} value={m}>{m}</option>
             ))}
           </select>

--- a/src/store/__tests__/sessions.test.ts
+++ b/src/store/__tests__/sessions.test.ts
@@ -25,10 +25,14 @@ describe('useSessionsStore', () => {
     useSessionsStore.setState({
       sessions: [],
       isLoading: false,
+      isFetchingMore: false,
       error: null,
+      hasMore: true,
       filterInterface: null,
       filterMachine: null,
       filterProject: null,
+      availableInterfaces: [],
+      availableMachines: [],
     });
   });
 
@@ -38,10 +42,14 @@ describe('useSessionsStore', () => {
     const state = useSessionsStore.getState();
     expect(state.sessions).toEqual([]);
     expect(state.isLoading).toBe(false);
+    expect(state.isFetchingMore).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.hasMore).toBe(true);
     expect(state.filterInterface).toBeNull();
     expect(state.filterMachine).toBeNull();
     expect(state.filterProject).toBeNull();
+    expect(state.availableInterfaces).toEqual([]);
+    expect(state.availableMachines).toEqual([]);
   });
 
   // ── fetchSessions ──────────────────────────────────────────────────────────
@@ -58,6 +66,26 @@ describe('useSessionsStore', () => {
       expect(state.isLoading).toBe(false);
       expect(state.error).toBeNull();
       expect(supabaseMock.from).toHaveBeenCalledWith('agent_sessions');
+    });
+
+    it('sets hasMore to false when fewer than page size returned', async () => {
+      const sessions = [makeSession()];
+      setMockResult({ data: sessions });
+
+      await useSessionsStore.getState().fetchSessions();
+
+      expect(useSessionsStore.getState().hasMore).toBe(false);
+    });
+
+    it('sets hasMore to true when page size rows returned', async () => {
+      const sessions = Array.from({ length: 25 }, (_, i) =>
+        makeSession({ id: `sess-${i}` }),
+      );
+      setMockResult({ data: sessions });
+
+      await useSessionsStore.getState().fetchSessions();
+
+      expect(useSessionsStore.getState().hasMore).toBe(true);
     });
 
     it('sets error on failure', async () => {
@@ -77,6 +105,106 @@ describe('useSessionsStore', () => {
       await useSessionsStore.getState().fetchSessions();
 
       expect(useSessionsStore.getState().sessions).toEqual([]);
+    });
+
+    it('clears existing sessions on new fetch', async () => {
+      useSessionsStore.setState({ sessions: [makeSession()] });
+      setMockResult({ data: [makeSession({ id: 'sess-new' })] });
+
+      await useSessionsStore.getState().fetchSessions();
+
+      expect(useSessionsStore.getState().sessions).toHaveLength(1);
+      expect(useSessionsStore.getState().sessions[0].id).toBe('sess-new');
+    });
+  });
+
+  // ── fetchMoreSessions ──────────────────────────────────────────────────────
+
+  describe('fetchMoreSessions', () => {
+    it('appends sessions to existing list', async () => {
+      useSessionsStore.setState({
+        sessions: [makeSession({ id: 'existing' })],
+        hasMore: true,
+      });
+      setMockResult({ data: [makeSession({ id: 'new-1' })] });
+
+      await useSessionsStore.getState().fetchMoreSessions();
+
+      const state = useSessionsStore.getState();
+      expect(state.sessions).toHaveLength(2);
+      expect(state.sessions[0].id).toBe('existing');
+      expect(state.sessions[1].id).toBe('new-1');
+    });
+
+    it('does nothing when hasMore is false', async () => {
+      useSessionsStore.setState({ hasMore: false });
+      setMockResult({ data: [makeSession()] });
+
+      await useSessionsStore.getState().fetchMoreSessions();
+
+      expect(useSessionsStore.getState().sessions).toEqual([]);
+    });
+
+    it('does nothing when already fetching more', async () => {
+      useSessionsStore.setState({ isFetchingMore: true, hasMore: true });
+      setMockResult({ data: [makeSession()] });
+
+      await useSessionsStore.getState().fetchMoreSessions();
+
+      expect(useSessionsStore.getState().sessions).toEqual([]);
+    });
+
+    it('sets hasMore to false when fewer than page size returned', async () => {
+      useSessionsStore.setState({
+        sessions: [makeSession({ id: 'existing' })],
+        hasMore: true,
+      });
+      setMockResult({ data: [makeSession({ id: 'last' })] });
+
+      await useSessionsStore.getState().fetchMoreSessions();
+
+      expect(useSessionsStore.getState().hasMore).toBe(false);
+    });
+  });
+
+  // ── fetchFilterOptions ─────────────────────────────────────────────────────
+
+  describe('fetchFilterOptions', () => {
+    it('extracts unique interface and machine values', async () => {
+      setMockResult({
+        data: [
+          { interface: 'claude-code', machine: 'midgard' },
+          { interface: 'claude.ai', machine: 'midgard' },
+          { interface: 'claude-code', machine: 'yggdrasil' },
+        ],
+      });
+
+      await useSessionsStore.getState().fetchFilterOptions();
+
+      const state = useSessionsStore.getState();
+      expect(state.availableInterfaces).toEqual(['claude-code', 'claude.ai']);
+      expect(state.availableMachines).toEqual(['midgard', 'yggdrasil']);
+    });
+
+    it('filters out null values', async () => {
+      setMockResult({
+        data: [
+          { interface: 'claude-code', machine: null },
+          { interface: 'claude.ai', machine: 'midgard' },
+        ],
+      });
+
+      await useSessionsStore.getState().fetchFilterOptions();
+
+      expect(useSessionsStore.getState().availableMachines).toEqual(['midgard']);
+    });
+
+    it('handles null data gracefully', async () => {
+      setMockResult({ data: null });
+
+      await useSessionsStore.getState().fetchFilterOptions();
+
+      expect(useSessionsStore.getState().availableInterfaces).toEqual([]);
     });
   });
 
@@ -102,61 +230,6 @@ describe('useSessionsStore', () => {
       useSessionsStore.getState().setFilterInterface('claude.ai');
       useSessionsStore.getState().setFilterInterface(null);
       expect(useSessionsStore.getState().filterInterface).toBeNull();
-    });
-  });
-
-  // ── filteredSessions ───────────────────────────────────────────────────────
-
-  describe('filteredSessions', () => {
-    const sessions: SessionRow[] = [
-      makeSession({ id: 's1', interface: 'claude-code', machine: 'midgard', project_id: 'proj-a' }),
-      makeSession({ id: 's2', interface: 'claude.ai', machine: 'midgard', project_id: 'proj-a' }),
-      makeSession({ id: 's3', interface: 'claude-code', machine: 'yggdrasil', project_id: 'proj-b' }),
-      makeSession({ id: 's4', interface: 'claude.ai', machine: 'yggdrasil', project_id: null }),
-    ];
-
-    beforeEach(() => {
-      useSessionsStore.setState({ sessions });
-    });
-
-    it('returns all sessions when no filters are set', () => {
-      expect(useSessionsStore.getState().filteredSessions()).toHaveLength(4);
-    });
-
-    it('filters by interface', () => {
-      useSessionsStore.getState().setFilterInterface('claude-code');
-      const result = useSessionsStore.getState().filteredSessions();
-      expect(result).toHaveLength(2);
-      expect(result.every((s) => s.interface === 'claude-code')).toBe(true);
-    });
-
-    it('filters by machine', () => {
-      useSessionsStore.getState().setFilterMachine('yggdrasil');
-      const result = useSessionsStore.getState().filteredSessions();
-      expect(result).toHaveLength(2);
-      expect(result.every((s) => s.machine === 'yggdrasil')).toBe(true);
-    });
-
-    it('filters by project', () => {
-      useSessionsStore.getState().setFilterProject('proj-a');
-      const result = useSessionsStore.getState().filteredSessions();
-      expect(result).toHaveLength(2);
-      expect(result.every((s) => s.project_id === 'proj-a')).toBe(true);
-    });
-
-    it('applies multiple filters with AND logic', () => {
-      useSessionsStore.getState().setFilterInterface('claude-code');
-      useSessionsStore.getState().setFilterMachine('midgard');
-      const result = useSessionsStore.getState().filteredSessions();
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('s1');
-    });
-
-    it('returns empty when no sessions match all filters', () => {
-      useSessionsStore.getState().setFilterInterface('claude.ai');
-      useSessionsStore.getState().setFilterMachine('midgard');
-      useSessionsStore.getState().setFilterProject('proj-b');
-      expect(useSessionsStore.getState().filteredSessions()).toHaveLength(0);
     });
   });
 

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -5,57 +5,116 @@ import type { Database } from '../database.types';
 
 type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
 
+const PAGE_SIZE = 25;
+
 interface SessionsState {
   sessions: SessionRow[];
   isLoading: boolean;
+  isFetchingMore: boolean;
   error: string | null;
+  hasMore: boolean;
   filterInterface: string | null;
   filterMachine: string | null;
   filterProject: string | null;
+  availableInterfaces: string[];
+  availableMachines: string[];
   fetchSessions: () => Promise<void>;
+  fetchMoreSessions: () => Promise<void>;
+  fetchFilterOptions: () => Promise<void>;
   clearError: () => void;
   setFilterInterface: (filter: string | null) => void;
   setFilterMachine: (filter: string | null) => void;
   setFilterProject: (filter: string | null) => void;
-  filteredSessions: () => SessionRow[];
 }
 
 export const useSessionsStore = create<SessionsState>()(
   devtools((set, get) => ({
     sessions: [],
     isLoading: false,
+    isFetchingMore: false,
     error: null,
+    hasMore: true,
     filterInterface: null,
     filterMachine: null,
     filterProject: null,
+    availableInterfaces: [],
+    availableMachines: [],
 
     fetchSessions: async () => {
-      set({ isLoading: true, error: null }, false, 'sessions/fetch:start');
-      const { data, error } = await supabase
+      set({ isLoading: true, error: null, sessions: [], hasMore: true }, false, 'sessions/fetch:start');
+      const { filterInterface, filterMachine, filterProject } = get();
+      let query = supabase
         .from('agent_sessions')
         .select('*')
-        .order('started_at', { ascending: false });
+        .order('started_at', { ascending: false })
+        .limit(PAGE_SIZE);
+      if (filterInterface) query = query.eq('interface', filterInterface);
+      if (filterMachine) query = query.eq('machine', filterMachine);
+      if (filterProject) query = query.eq('project_id', filterProject);
+      const { data, error } = await query;
       if (error) {
         set({ isLoading: false, error: error.message }, false, 'sessions/fetch:error');
         return;
       }
-      set({ sessions: data ?? [], isLoading: false, error: null }, false, 'sessions/fetch:success');
+      const rows = data ?? [];
+      set({
+        sessions: rows,
+        isLoading: false,
+        error: null,
+        hasMore: rows.length >= PAGE_SIZE,
+      }, false, 'sessions/fetch:success');
+    },
+
+    fetchMoreSessions: async () => {
+      const { sessions, isFetchingMore, hasMore, filterInterface, filterMachine, filterProject } = get();
+      if (isFetchingMore || !hasMore) return;
+      set({ isFetchingMore: true, error: null }, false, 'sessions/fetchMore:start');
+      const offset = sessions.length;
+      let query = supabase
+        .from('agent_sessions')
+        .select('*')
+        .order('started_at', { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1);
+      if (filterInterface) query = query.eq('interface', filterInterface);
+      if (filterMachine) query = query.eq('machine', filterMachine);
+      if (filterProject) query = query.eq('project_id', filterProject);
+      const { data, error } = await query;
+      if (error) {
+        set({ isFetchingMore: false, error: error.message }, false, 'sessions/fetchMore:error');
+        return;
+      }
+      const rows = data ?? [];
+      set({
+        sessions: [...get().sessions, ...rows],
+        isFetchingMore: false,
+        error: null,
+        hasMore: rows.length >= PAGE_SIZE,
+      }, false, 'sessions/fetchMore:success');
+    },
+
+    fetchFilterOptions: async () => {
+      const { data } = await supabase
+        .from('agent_sessions')
+        .select('interface, machine');
+      if (!data) return;
+      const interfaces = [...new Set(data.map((r) => r.interface).filter(Boolean))] as string[];
+      const machines = [...new Set(data.map((r) => r.machine).filter(Boolean))] as string[];
+      set({ availableInterfaces: interfaces.sort(), availableMachines: machines.sort() }, false, 'sessions/filterOptions');
     },
 
     clearError: () => set({ error: null }, false, 'sessions/clearError'),
 
-    setFilterInterface: (filter) => set({ filterInterface: filter }, false, 'sessions/filter:interface'),
-    setFilterMachine: (filter) => set({ filterMachine: filter }, false, 'sessions/filter:machine'),
-    setFilterProject: (filter) => set({ filterProject: filter }, false, 'sessions/filter:project'),
-
-    filteredSessions: () => {
-      const { sessions, filterInterface, filterMachine, filterProject } = get();
-      return sessions.filter((s) => {
-        if (filterInterface && s.interface !== filterInterface) return false;
-        if (filterMachine && s.machine !== filterMachine) return false;
-        if (filterProject && s.project_id !== filterProject) return false;
-        return true;
-      });
+    setFilterInterface: (filter) => {
+      set({ filterInterface: filter }, false, 'sessions/filter:interface');
+      void get().fetchSessions();
+    },
+    setFilterMachine: (filter) => {
+      set({ filterMachine: filter }, false, 'sessions/filter:machine');
+      void get().fetchSessions();
+    },
+    setFilterProject: (filter) => {
+      set({ filterProject: filter }, false, 'sessions/filter:project');
+      void get().fetchSessions();
     },
   }), { name: 'sessions-store' }),
 );


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- **Offset pagination**: Agent sessions now load 25 at a time using Supabase `.range()` / `.limit()` instead of fetching the entire table
- **Server-side filtering**: Interface, machine, and project filters are pushed to the Supabase query via `.eq()` — previously filtering happened client-side after loading all rows
- **"Load more" button**: SessionFeed shows a "Load more" button when additional pages are available, with a dedicated `isFetchingMore` loading state to avoid UI flicker
- **Filter options query**: Dropdown values are fetched via a lightweight column-only query (`select('interface, machine')`) so filter options remain complete regardless of which page is loaded

## Test plan

- [x] All 81 existing tests pass
- [x] TypeScript type checking clean
- [x] ESLint clean
- [x] Production build succeeds
- [ ] Manual: verify initial page loads 25 sessions
- [ ] Manual: verify "Load more" fetches next page and appends
- [ ] Manual: verify filter dropdowns show all available values
- [ ] Manual: verify changing a filter resets to first page with server-side results

Closes [ENG-6](https://linear.app/alecv/issue/ENG-6/add-pagination-for-agent-sessions)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->