### PR TITLE
Add client-side form validation

### DIFF
--- a/src/components/detail/CreateProjectDetail.tsx
+++ b/src/components/detail/CreateProjectDetail.tsx
@@ -5,6 +5,12 @@ import { useUIStore } from '../../store/ui';
 
 const STATUS_OPTIONS = ['idea', 'todo', 'in-progress', 'paused', 'done'] as const;
 
+function isValidPriority(value: string): boolean {
+  if (value === '') return true;
+  const num = Number(value);
+  return Number.isInteger(num) && num >= 0 && num <= 5;
+}
+
 export function CreateProjectDetail() {
   const createProject = useProjectsStore((s) => s.createProject);
   const selectProject = useProjectsStore((s) => s.selectProject);
@@ -16,9 +22,18 @@ export function CreateProjectDetail() {
   const [priority, setPriority] = useState('');
   const [techStack, setTechStack] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const [errors, setErrors] = useState<{ name?: string; priority?: string }>({});
+
+  const validate = (): boolean => {
+    const next: { name?: string; priority?: string } = {};
+    if (!name.trim()) next.name = 'Project name is required';
+    if (!isValidPriority(priority)) next.priority = 'Priority must be 0–5';
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
 
   const handleCreate = async () => {
-    if (!name.trim()) return;
+    if (!validate()) return;
     setIsSaving(true);
 
     const tags = techStack
@@ -64,13 +79,23 @@ export function CreateProjectDetail() {
         <input
           id="project-name"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (errors.name) setErrors((prev) => ({ ...prev, name: undefined }));
+          }}
           placeholder="Project name"
           autoFocus
-          className="w-full bg-transparent border border-border rounded px-2 py-1.5 text-sm text-normal
-            placeholder:text-low/40 focus:outline-none focus:border-brand/50 focus:ring-1 focus:ring-brand/20
-            transition-colors"
+          aria-invalid={!!errors.name}
+          className={`w-full bg-transparent border rounded px-2 py-1.5 text-sm text-normal
+            placeholder:text-low/40 focus:outline-none focus:ring-1 transition-colors ${
+              errors.name
+                ? 'border-error focus:border-error focus:ring-error/20'
+                : 'border-border focus:border-brand/50 focus:ring-brand/20'
+            }`}
         />
+        {errors.name && (
+          <p className="mt-1 text-xs text-error">{errors.name}</p>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-3">
@@ -102,12 +127,22 @@ export function CreateProjectDetail() {
             min={0}
             max={5}
             value={priority}
-            onChange={(e) => setPriority(e.target.value)}
+            onChange={(e) => {
+              setPriority(e.target.value);
+              if (errors.priority) setErrors((prev) => ({ ...prev, priority: undefined }));
+            }}
             placeholder="0–5"
-            className="w-full bg-transparent border border-border rounded px-2 py-1.5 text-sm text-normal
-              placeholder:text-low/40 focus:outline-none focus:border-brand/50 focus:ring-1 focus:ring-brand/20
-              transition-colors"
+            aria-invalid={!!errors.priority}
+            className={`w-full bg-transparent border rounded px-2 py-1.5 text-sm text-normal
+              placeholder:text-low/40 focus:outline-none focus:ring-1 transition-colors ${
+                errors.priority
+                  ? 'border-error focus:border-error focus:ring-error/20'
+                  : 'border-border focus:border-brand/50 focus:ring-brand/20'
+              }`}
           />
+          {errors.priority && (
+            <p className="mt-1 text-xs text-error">{errors.priority}</p>
+          )}
         </div>
       </div>
 
@@ -145,7 +180,7 @@ export function CreateProjectDetail() {
       <div className="flex gap-2 pt-2">
         <button
           onClick={() => void handleCreate()}
-          disabled={!name.trim() || isSaving}
+          disabled={isSaving}
           className="flex-1 px-3 py-2 bg-brand text-white rounded-lg text-sm font-medium
             hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >

--- a/src/components/detail/ProjectDetail.tsx
+++ b/src/components/detail/ProjectDetail.tsx
@@ -214,6 +214,7 @@ export function ProjectDetail() {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [memories, setMemories] = useState<MemoryRow[]>([]);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [priorityError, setPriorityError] = useState('');
   const priorityTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
   const selectedProjectId = selectedProject?.id ?? null;
@@ -340,23 +341,44 @@ export function ProjectDetail() {
             max={5}
             value={localPriority}
             onChange={(e) => {
-              setLocalPriority(e.target.value);
+              const raw = e.target.value;
+              setLocalPriority(raw);
+              const num = Number(raw);
+              if (raw !== '' && (!Number.isInteger(num) || num < 0 || num > 5)) {
+                setPriorityError('Priority must be 0–5');
+                if (priorityTimerRef.current) clearTimeout(priorityTimerRef.current);
+                return;
+              }
+              setPriorityError('');
               if (priorityTimerRef.current) clearTimeout(priorityTimerRef.current);
               priorityTimerRef.current = setTimeout(() => {
-                const val = e.target.value === '' ? null : Number(e.target.value);
+                const val = raw === '' ? null : num;
                 handleSave('priority', val);
               }, 600);
             }}
             onBlur={() => {
               if (priorityTimerRef.current) clearTimeout(priorityTimerRef.current);
-              const val = localPriority === '' ? null : Number(localPriority);
+              const num = Number(localPriority);
+              if (localPriority !== '' && (!Number.isInteger(num) || num < 0 || num > 5)) {
+                setPriorityError('Priority must be 0–5');
+                return;
+              }
+              setPriorityError('');
+              const val = localPriority === '' ? null : num;
               handleSave('priority', val);
             }}
             placeholder="0–5"
-            className="w-full bg-transparent border border-border rounded px-2 py-1.5 text-sm text-normal
-              placeholder:text-low/40 focus:outline-none focus:border-brand/50 focus:ring-1 focus:ring-brand/20
-              transition-colors"
+            aria-invalid={!!priorityError}
+            className={`w-full bg-transparent border rounded px-2 py-1.5 text-sm text-normal
+              placeholder:text-low/40 focus:outline-none focus:ring-1 transition-colors ${
+                priorityError
+                  ? 'border-error focus:border-error focus:ring-error/20'
+                  : 'border-border focus:border-brand/50 focus:ring-brand/20'
+              }`}
           />
+          {priorityError && (
+            <p className="mt-1 text-xs text-error">{priorityError}</p>
+          )}
         </div>
       </div>
 

--- a/src/components/detail/ToolDetail.tsx
+++ b/src/components/detail/ToolDetail.tsx
@@ -57,8 +57,24 @@ export function ToolDetail() {
   const [formData, setFormData] = useState<ToolFormData>(initialFormData);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [errors, setErrors] = useState<{ name?: string; url?: string }>({});
+
+  const validate = (): boolean => {
+    const next: { name?: string; url?: string } = {};
+    if (!formData.name.trim()) next.name = 'Tool name is required';
+    if (formData.url.trim()) {
+      try {
+        new URL(formData.url.trim());
+      } catch {
+        next.url = 'Enter a valid URL (e.g. https://example.com)';
+      }
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
 
   const handleSave = async () => {
+    if (!validate()) return;
     setIsSaving(true);
     let result;
     if (isNew) {
@@ -121,15 +137,26 @@ export function ToolDetail() {
       </div>
 
       <div>
-        <label htmlFor="tool-name" className="text-low text-xs block mb-1">Name</label>
+        <label htmlFor="tool-name" className="text-low text-xs block mb-1">Name *</label>
         <input
           id="tool-name"
           type="text"
           value={formData.name}
-          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          className="w-full bg-muted border border-border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 focus:ring-brand"
+          onChange={(e) => {
+            setFormData({ ...formData, name: e.target.value });
+            if (errors.name) setErrors((prev) => ({ ...prev, name: undefined }));
+          }}
+          aria-invalid={!!errors.name}
+          className={`w-full bg-muted border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 ${
+            errors.name
+              ? 'border-error focus:ring-error/20'
+              : 'border-border focus:ring-brand'
+          }`}
           placeholder="Tool name"
         />
+        {errors.name && (
+          <p className="mt-1 text-xs text-error">{errors.name}</p>
+        )}
       </div>
 
       <div>
@@ -208,10 +235,21 @@ export function ToolDetail() {
           id="tool-url"
           type="url"
           value={formData.url}
-          onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-          className="w-full bg-muted border border-border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 focus:ring-brand"
+          onChange={(e) => {
+            setFormData({ ...formData, url: e.target.value });
+            if (errors.url) setErrors((prev) => ({ ...prev, url: undefined }));
+          }}
+          aria-invalid={!!errors.url}
+          className={`w-full bg-muted border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 ${
+            errors.url
+              ? 'border-error focus:ring-error/20'
+              : 'border-border focus:ring-brand'
+          }`}
           placeholder="https://..."
         />
+        {errors.url && (
+          <p className="mt-1 text-xs text-error">{errors.url}</p>
+        )}
       </div>
 
       <div>

--- a/src/components/detail/__tests__/CreateProjectDetail.test.tsx
+++ b/src/components/detail/__tests__/CreateProjectDetail.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CreateProjectDetail } from '../CreateProjectDetail';
+
+// ── Store mocks ─────────────────────────────────────────────────
+const mockCreateProject = vi.fn();
+const mockSelectProject = vi.fn();
+const mockClosePanel = vi.fn();
+
+vi.mock('../../../store/projects', () => ({
+  useProjectsStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      createProject: mockCreateProject,
+      selectProject: mockSelectProject,
+    }),
+}));
+
+vi.mock('../../../store/ui', () => ({
+  useUIStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      closePanel: mockClosePanel,
+    }),
+}));
+
+describe('CreateProjectDetail validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateProject.mockResolvedValue({ id: '1', name: 'Test' });
+  });
+
+  it('shows error when name is empty on submit', () => {
+    render(<CreateProjectDetail />);
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.getByText('Project name is required')).toBeInTheDocument();
+    expect(mockCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('shows error when name is only whitespace', () => {
+    render(<CreateProjectDetail />);
+    const nameInput = screen.getByPlaceholderText('Project name');
+    fireEvent.change(nameInput, { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.getByText('Project name is required')).toBeInTheDocument();
+    expect(mockCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('clears name error on typing', () => {
+    render(<CreateProjectDetail />);
+    fireEvent.click(screen.getByText('Create Project'));
+    expect(screen.getByText('Project name is required')).toBeInTheDocument();
+
+    const nameInput = screen.getByPlaceholderText('Project name');
+    fireEvent.change(nameInput, { target: { value: 'A' } });
+    expect(screen.queryByText('Project name is required')).not.toBeInTheDocument();
+  });
+
+  it('shows error when priority is out of range', () => {
+    render(<CreateProjectDetail />);
+    const nameInput = screen.getByPlaceholderText('Project name');
+    const priorityInput = screen.getByPlaceholderText('0–5');
+
+    fireEvent.change(nameInput, { target: { value: 'My Project' } });
+    fireEvent.change(priorityInput, { target: { value: '10' } });
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.getByText('Priority must be 0–5')).toBeInTheDocument();
+    expect(mockCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('shows error when priority is negative', () => {
+    render(<CreateProjectDetail />);
+    const nameInput = screen.getByPlaceholderText('Project name');
+    const priorityInput = screen.getByPlaceholderText('0–5');
+
+    fireEvent.change(nameInput, { target: { value: 'My Project' } });
+    fireEvent.change(priorityInput, { target: { value: '-1' } });
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.getByText('Priority must be 0–5')).toBeInTheDocument();
+    expect(mockCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('allows empty priority (optional field)', async () => {
+    render(<CreateProjectDetail />);
+    const nameInput = screen.getByPlaceholderText('Project name');
+
+    fireEvent.change(nameInput, { target: { value: 'My Project' } });
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
+    expect(mockCreateProject).toHaveBeenCalled();
+  });
+
+  it('allows valid priority values 0–5', async () => {
+    render(<CreateProjectDetail />);
+    const nameInput = screen.getByPlaceholderText('Project name');
+    const priorityInput = screen.getByPlaceholderText('0–5');
+
+    fireEvent.change(nameInput, { target: { value: 'My Project' } });
+    fireEvent.change(priorityInput, { target: { value: '3' } });
+    fireEvent.click(screen.getByText('Create Project'));
+
+    expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
+    expect(mockCreateProject).toHaveBeenCalled();
+  });
+
+  it('sets aria-invalid on name input when error is shown', () => {
+    render(<CreateProjectDetail />);
+    fireEvent.click(screen.getByText('Create Project'));
+
+    const nameInput = screen.getByPlaceholderText('Project name');
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/src/components/detail/__tests__/ToolDetail.test.tsx
+++ b/src/components/detail/__tests__/ToolDetail.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToolDetail } from '../ToolDetail';
+
+// ── Store mocks ─────────────────────────────────────────────────
+const mockCreateTool = vi.fn();
+const mockUpdateTool = vi.fn();
+const mockDeleteTool = vi.fn();
+const mockSelectTool = vi.fn();
+const mockClosePanel = vi.fn();
+
+vi.mock('../../../store/tools', () => ({
+  useToolsStore: () => ({
+    selectedTool: null,
+    selectedToolId: 'new',
+    createTool: mockCreateTool,
+    updateTool: mockUpdateTool,
+    deleteTool: mockDeleteTool,
+    selectTool: mockSelectTool,
+  }),
+}));
+
+vi.mock('../../../store/ui', () => ({
+  useUIStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      closePanel: mockClosePanel,
+    }),
+}));
+
+describe('ToolDetail validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateTool.mockResolvedValue({ id: '1', name: 'Test Tool' });
+  });
+
+  it('shows error when name is empty on save', () => {
+    render(<ToolDetail />);
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    expect(screen.getByText('Tool name is required')).toBeInTheDocument();
+    expect(mockCreateTool).not.toHaveBeenCalled();
+  });
+
+  it('clears name error on typing', () => {
+    render(<ToolDetail />);
+    fireEvent.click(screen.getByLabelText('Save tool'));
+    expect(screen.getByText('Tool name is required')).toBeInTheDocument();
+
+    const nameInput = screen.getByPlaceholderText('Tool name');
+    fireEvent.change(nameInput, { target: { value: 'A' } });
+    expect(screen.queryByText('Tool name is required')).not.toBeInTheDocument();
+  });
+
+  it('shows error for invalid URL', () => {
+    render(<ToolDetail />);
+    const nameInput = screen.getByPlaceholderText('Tool name');
+    const urlInput = screen.getByPlaceholderText('https://...');
+
+    fireEvent.change(nameInput, { target: { value: 'My Tool' } });
+    fireEvent.change(urlInput, { target: { value: 'not-a-url' } });
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    expect(screen.getByText('Enter a valid URL (e.g. https://example.com)')).toBeInTheDocument();
+    expect(mockCreateTool).not.toHaveBeenCalled();
+  });
+
+  it('allows empty URL (optional field)', async () => {
+    render(<ToolDetail />);
+    const nameInput = screen.getByPlaceholderText('Tool name');
+
+    fireEvent.change(nameInput, { target: { value: 'My Tool' } });
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
+    expect(mockCreateTool).toHaveBeenCalled();
+  });
+
+  it('allows valid URLs', async () => {
+    render(<ToolDetail />);
+    const nameInput = screen.getByPlaceholderText('Tool name');
+    const urlInput = screen.getByPlaceholderText('https://...');
+
+    fireEvent.change(nameInput, { target: { value: 'My Tool' } });
+    fireEvent.change(urlInput, { target: { value: 'https://example.com' } });
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
+    expect(mockCreateTool).toHaveBeenCalled();
+  });
+
+  it('clears URL error on typing', () => {
+    render(<ToolDetail />);
+    const nameInput = screen.getByPlaceholderText('Tool name');
+    const urlInput = screen.getByPlaceholderText('https://...');
+
+    fireEvent.change(nameInput, { target: { value: 'My Tool' } });
+    fireEvent.change(urlInput, { target: { value: 'bad' } });
+    fireEvent.click(screen.getByLabelText('Save tool'));
+    expect(screen.getByText('Enter a valid URL (e.g. https://example.com)')).toBeInTheDocument();
+
+    fireEvent.change(urlInput, { target: { value: 'https://fixed.com' } });
+    expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
+  });
+
+  it('shows name label with required indicator', () => {
+    render(<ToolDetail />);
+    expect(screen.getByText('Name *')).toBeInTheDocument();
+  });
+
+  it('sets aria-invalid on name input when error is shown', () => {
+    render(<ToolDetail />);
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    const nameInput = screen.getByPlaceholderText('Tool name');
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('shows both errors when name is empty and URL is invalid', () => {
+    render(<ToolDetail />);
+    const urlInput = screen.getByPlaceholderText('https://...');
+
+    fireEvent.change(urlInput, { target: { value: 'not-a-url' } });
+    fireEvent.click(screen.getByLabelText('Save tool'));
+
+    expect(screen.getByText('Tool name is required')).toBeInTheDocument();
+    expect(screen.getByText('Enter a valid URL (e.g. https://example.com)')).toBeInTheDocument();
+    expect(mockCreateTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- **CreateProjectDetail**: Validates name (required) and priority (0–5 range) on submit, with inline error messages and red border styling
- **ProjectDetail**: Validates priority (0–5) on change/blur, blocks auto-save when value is out of range
- **ToolDetail**: Validates name (required, marked with `*`) and URL format on save, with inline error messages

All validated fields use `aria-invalid` for accessibility, show contextual error text below the input, and clear errors as the user corrects their input. No validation library — simple inline checks per the issue scope.

## Test plan

- [x] 98/98 tests pass (17 new validation tests + 81 existing)
- [x] TypeScript type check clean
- [x] ESLint clean
- [ ] Manual: create project with empty name → error shown, can't submit
- [ ] Manual: enter priority > 5 or < 0 → error shown on both create and edit forms
- [ ] Manual: create tool with empty name → error shown, can't save
- [ ] Manual: enter invalid URL in tool form → error shown on save
- [ ] Manual: verify errors clear when input is corrected

Resolves [ENG-8](https://linear.app/alecv/issue/ENG-8/add-client-side-form-validation)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
