### PR TITLE
Fix fragile realtime subscription lifecycle in stores

### DIFF
--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -11,9 +11,7 @@ export default function BoardPage() {
   useEffect(() => {
     void fetchProjects();
     const cleanup = subscribeToProjects();
-    return () => {
-      void cleanup.then((fn) => fn?.());
-    };
+    return cleanup;
   }, [fetchProjects, subscribeToProjects]);
 
   if (isLoading && projects.length === 0) {

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -11,9 +11,7 @@ export default function ToolsPage() {
   useEffect(() => {
     void fetchTools();
     const cleanup = subscribeToTools();
-    return () => {
-      void cleanup.then((fn) => fn?.());
-    };
+    return cleanup;
   }, [fetchTools, subscribeToTools]);
 
   return (

--- a/src/store/__tests__/projects.test.ts
+++ b/src/store/__tests__/projects.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useProjectsStore } from '../projects';
 import { setMockResult, resetMockResult, supabaseMock } from '../../test/setup';
 import type { Database } from '../../database.types';
@@ -25,6 +25,7 @@ const makeProject = (overrides: Partial<ProjectRow> = {}): ProjectRow => ({
 
 describe('useProjectsStore', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetMockResult();
     useProjectsStore.setState({
       projects: [],
@@ -304,20 +305,39 @@ describe('useProjectsStore', () => {
   // ── subscribeToProjects ────────────────────────────────────────────────────
 
   describe('subscribeToProjects', () => {
-    it('sets up a realtime channel and returns unsubscribe function', async () => {
-      const unsubscribe = await useProjectsStore.getState().subscribeToProjects();
+    it('sets up a realtime channel and returns unsubscribe function', () => {
+      const unsubscribe = useProjectsStore.getState().subscribeToProjects();
 
       expect(supabaseMock.channel).toHaveBeenCalledWith('muninn-projects');
       expect(supabaseMock.__channelMock.on).toHaveBeenCalled();
       expect(supabaseMock.__channelMock.subscribe).toHaveBeenCalled();
       expect(typeof unsubscribe).toBe('function');
+
+      unsubscribe();
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
     });
 
-    it('removes existing channel before creating a new one', async () => {
-      await useProjectsStore.getState().subscribeToProjects();
-      await useProjectsStore.getState().subscribeToProjects();
+    it('keeps one shared channel until the last subscriber unsubscribes', () => {
+      const unsubscribeFirst = useProjectsStore.getState().subscribeToProjects();
+      const unsubscribeSecond = useProjectsStore.getState().subscribeToProjects();
 
-      expect(supabaseMock.removeChannel).toHaveBeenCalled();
+      expect(supabaseMock.channel).toHaveBeenCalledTimes(1);
+      expect(supabaseMock.__channelMock.subscribe).toHaveBeenCalledTimes(1);
+
+      unsubscribeFirst();
+      expect(supabaseMock.removeChannel).not.toHaveBeenCalled();
+
+      unsubscribeSecond();
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows cleanup to be called more than once safely', () => {
+      const unsubscribe = useProjectsStore.getState().subscribeToProjects();
+
+      unsubscribe();
+      unsubscribe();
+
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/store/__tests__/tools.test.ts
+++ b/src/store/__tests__/tools.test.ts
@@ -23,6 +23,7 @@ const makeTool = (overrides: Partial<ToolRow> = {}): ToolRow => ({
 
 describe('useToolsStore', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetMockResult();
     useToolsStore.setState({
       tools: [],
@@ -335,13 +336,39 @@ describe('useToolsStore', () => {
   // ── subscribeToTools ───────────────────────────────────────────────────────
 
   describe('subscribeToTools', () => {
-    it('sets up a realtime channel and returns unsubscribe function', async () => {
-      const unsubscribe = await useToolsStore.getState().subscribeToTools();
+    it('sets up a realtime channel and returns unsubscribe function', () => {
+      const unsubscribe = useToolsStore.getState().subscribeToTools();
 
       expect(supabaseMock.channel).toHaveBeenCalledWith('muninn-tools');
       expect(supabaseMock.__channelMock.on).toHaveBeenCalled();
       expect(supabaseMock.__channelMock.subscribe).toHaveBeenCalled();
       expect(typeof unsubscribe).toBe('function');
+
+      unsubscribe();
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps one shared channel until all subscribers unsubscribe', () => {
+      const unsubscribeFirst = useToolsStore.getState().subscribeToTools();
+      const unsubscribeSecond = useToolsStore.getState().subscribeToTools();
+
+      expect(supabaseMock.channel).toHaveBeenCalledTimes(1);
+      expect(supabaseMock.__channelMock.subscribe).toHaveBeenCalledTimes(1);
+
+      unsubscribeFirst();
+      expect(supabaseMock.removeChannel).not.toHaveBeenCalled();
+
+      unsubscribeSecond();
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows cleanup to be called more than once safely', () => {
+      const unsubscribe = useToolsStore.getState().subscribeToTools();
+
+      unsubscribe();
+      unsubscribe();
+
+      expect(supabaseMock.removeChannel).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -16,7 +16,7 @@ interface ProjectsState {
   isLoading: boolean;
   error: string | null;
   fetchProjects: () => Promise<void>;
-  subscribeToProjects: () => Promise<() => Promise<void> | void>;
+  subscribeToProjects: () => () => void;
   createProject: (project: ProjectInsert) => Promise<ProjectRow | null>;
   updateProject: (id: string, updates: ProjectUpdate) => Promise<ProjectRow | null>;
   deleteProject: (id: string) => Promise<boolean>;
@@ -27,7 +27,34 @@ interface ProjectsState {
 }
 
 const boardColumns = ['idea', 'todo', 'in-progress', 'paused', 'done'];
-let projectsChannel: RealtimeChannel | null = null;
+interface RealtimeSubscriptionState {
+  channel: RealtimeChannel | null;
+  subscriberCount: number;
+}
+
+type RealtimeRegistry = Record<string, RealtimeSubscriptionState>;
+type GlobalRealtimeRegistry = typeof globalThis & {
+  __muninnRealtimeRegistry__?: RealtimeRegistry;
+};
+
+const getRealtimeRegistry = (): RealtimeRegistry => {
+  const globalRef = globalThis as GlobalRealtimeRegistry;
+  if (!globalRef.__muninnRealtimeRegistry__) {
+    globalRef.__muninnRealtimeRegistry__ = {};
+  }
+  return globalRef.__muninnRealtimeRegistry__;
+};
+
+const getProjectsSubscriptionState = (): RealtimeSubscriptionState => {
+  const registry = getRealtimeRegistry();
+  if (!registry.projects) {
+    registry.projects = {
+      channel: null,
+      subscriberCount: 0,
+    };
+  }
+  return registry.projects;
+};
 
 const syncSelectedProject = (state: ProjectsState, selectedProjectId = state.selectedProjectId) =>
   state.projects.find((project) => project.id === selectedProjectId) ?? null;
@@ -68,23 +95,32 @@ export const useProjectsStore = create<ProjectsState>()(
       );
     },
 
-    subscribeToProjects: async () => {
-      if (projectsChannel) {
-        await supabase.removeChannel(projectsChannel);
-        projectsChannel = null;
+    subscribeToProjects: () => {
+      const subscription = getProjectsSubscriptionState();
+      subscription.subscriberCount += 1;
+
+      if (!subscription.channel) {
+        subscription.channel = supabase
+          .channel('muninn-projects')
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'projects' }, () => {
+            void get().fetchProjects();
+          })
+          .subscribe();
       }
 
-      projectsChannel = supabase
-        .channel('muninn-projects')
-        .on('postgres_changes', { event: '*', schema: 'public', table: 'projects' }, () => {
-          void get().fetchProjects();
-        })
-        .subscribe();
+      let hasCleanedUp = false;
+      return () => {
+        if (hasCleanedUp) return;
+        hasCleanedUp = true;
 
-      return async () => {
-        if (!projectsChannel) return;
-        await supabase.removeChannel(projectsChannel);
-        projectsChannel = null;
+        const currentSubscription = getProjectsSubscriptionState();
+        currentSubscription.subscriberCount = Math.max(0, currentSubscription.subscriberCount - 1);
+
+        if (currentSubscription.subscriberCount > 0 || !currentSubscription.channel) return;
+
+        const channel = currentSubscription.channel;
+        currentSubscription.channel = null;
+        void supabase.removeChannel(channel);
       };
     },
 

--- a/src/store/tools.ts
+++ b/src/store/tools.ts
@@ -16,7 +16,7 @@ interface ToolsState {
   isLoading: boolean;
   error: string | null;
   fetchTools: () => Promise<void>;
-  subscribeToTools: () => Promise<() => Promise<void> | void>;
+  subscribeToTools: () => () => void;
   createTool: (tool: ToolInsert) => Promise<ToolRow | null>;
   updateTool: (id: string, updates: ToolUpdate) => Promise<ToolRow | null>;
   deleteTool: (id: string) => Promise<boolean>;
@@ -28,7 +28,34 @@ interface ToolsState {
   renewingWithin30Days: () => number;
 }
 
-let toolsChannel: RealtimeChannel | null = null;
+interface RealtimeSubscriptionState {
+  channel: RealtimeChannel | null;
+  subscriberCount: number;
+}
+
+type RealtimeRegistry = Record<string, RealtimeSubscriptionState>;
+type GlobalRealtimeRegistry = typeof globalThis & {
+  __muninnRealtimeRegistry__?: RealtimeRegistry;
+};
+
+const getRealtimeRegistry = (): RealtimeRegistry => {
+  const globalRef = globalThis as GlobalRealtimeRegistry;
+  if (!globalRef.__muninnRealtimeRegistry__) {
+    globalRef.__muninnRealtimeRegistry__ = {};
+  }
+  return globalRef.__muninnRealtimeRegistry__;
+};
+
+const getToolsSubscriptionState = (): RealtimeSubscriptionState => {
+  const registry = getRealtimeRegistry();
+  if (!registry.tools) {
+    registry.tools = {
+      channel: null,
+      subscriberCount: 0,
+    };
+  }
+  return registry.tools;
+};
 
 const syncSelectedTool = (state: ToolsState, selectedToolId = state.selectedToolId) =>
   state.tools.find((tool) => tool.id === selectedToolId) ?? null;
@@ -65,23 +92,32 @@ export const useToolsStore = create<ToolsState>()(
         );
       },
 
-      subscribeToTools: async () => {
-        if (toolsChannel) {
-          await supabase.removeChannel(toolsChannel);
-          toolsChannel = null;
+      subscribeToTools: () => {
+        const subscription = getToolsSubscriptionState();
+        subscription.subscriberCount += 1;
+
+        if (!subscription.channel) {
+          subscription.channel = supabase
+            .channel('muninn-tools')
+            .on('postgres_changes', { event: '*', schema: 'public', table: 'tools' }, () => {
+              void get().fetchTools();
+            })
+            .subscribe();
         }
 
-        toolsChannel = supabase
-          .channel('muninn-tools')
-          .on('postgres_changes', { event: '*', schema: 'public', table: 'tools' }, () => {
-            void get().fetchTools();
-          })
-          .subscribe();
+        let hasCleanedUp = false;
+        return () => {
+          if (hasCleanedUp) return;
+          hasCleanedUp = true;
 
-        return async () => {
-          if (!toolsChannel) return;
-          await supabase.removeChannel(toolsChannel);
-          toolsChannel = null;
+          const currentSubscription = getToolsSubscriptionState();
+          currentSubscription.subscriberCount = Math.max(0, currentSubscription.subscriberCount - 1);
+
+          if (currentSubscription.subscriberCount > 0 || !currentSubscription.channel) return;
+
+          const channel = currentSubscription.channel;
+          currentSubscription.channel = null;
+          void supabase.removeChannel(channel);
         };
       },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move realtime channel lifecycle ownership into durable store-adjacent subscription state keyed on `globalThis`, so channel references survive HMR module replacement instead of being lost in module-local `let` bindings
- change `subscribeToProjects` and `subscribeToTools` to synchronous cleanup APIs with per-subscriber reference counting and idempotent teardown guards
- keep exactly one active channel per table and only remove it when the final subscriber unsubscribes, preventing double-subscribe clobbering across multiple mounted components
- update `BoardPage` and `ToolsPage` effects to return cleanup callbacks directly (eliminates the promise/unmount race from `cleanup.then(...)`)
- expand store tests to cover shared-channel behavior and safe double cleanup semantics

## Testing
- `npm test -- src/store/__tests__/projects.test.ts src/store/__tests__/tools.test.ts`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-9](https://linear.app/alecv/issue/ENG-9/fragile-realtime-subscription-lifecycle-module-level-channel-state)

<div><a href="https://cursor.com/agents/bc-afefe711-7afc-4873-8c48-b8385adeb2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afefe711-7afc-4873-8c48-b8385adeb2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

