### PR TITLE
Add search and filtering to Board and Tools views

### DIFF
--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -16,8 +16,13 @@ export function KanbanBoard() {
 
   const visibleProjects = filteredProjects();
 
-  const getProjectsForColumn = (columnId: string, source = visibleProjects) =>
-    source
+  const getProjectsForColumn = (columnId: string) =>
+    visibleProjects
+      .filter((p) => p.board_status === columnId)
+      .sort((a, b) => (a.board_position || 0) - (b.board_position || 0));
+
+  const getAllProjectsForColumn = (columnId: string) =>
+    projects
       .filter((p) => p.board_status === columnId)
       .sort((a, b) => (a.board_position || 0) - (b.board_position || 0));
 
@@ -30,21 +35,56 @@ export function KanbanBoard() {
       return;
     }
 
-    // Use ALL projects (not filtered) so positions don't collide with hidden items
-    const columnProjects = getProjectsForColumn(destination.droppableId, projects);
+    // destination.index is relative to the rendered (filtered) list, so use
+    // the filtered list to identify the intended neighbor projects.
+    const visibleColumn = getProjectsForColumn(destination.droppableId);
+    // The full unfiltered column is used to find a safe position that doesn't
+    // collide with hidden items between the two visible neighbors.
+    const allColumn = getAllProjectsForColumn(destination.droppableId);
 
     // Fractional positioning: interpolate between siblings for stable reorder
     let newPosition: number;
-    if (columnProjects.length === 0) {
-      newPosition = 1000;
+    if (visibleColumn.length === 0) {
+      // Empty visible column — place after all (including hidden) items
+      if (allColumn.length === 0) {
+        newPosition = 1000;
+      } else {
+        newPosition = (allColumn[allColumn.length - 1]?.board_position || 0) + 1000;
+      }
     } else if (destination.index === 0) {
-      newPosition = (columnProjects[0]?.board_position || 0) - 1000;
-    } else if (destination.index >= columnProjects.length) {
-      newPosition = (columnProjects[columnProjects.length - 1]?.board_position || 0) + 1000;
+      // Before the first visible item — place before all items up to that point
+      const firstVisible = visibleColumn[0];
+      const firstVisibleIdx = allColumn.findIndex((p) => p.id === firstVisible.id);
+      if (firstVisibleIdx <= 0) {
+        newPosition = (firstVisible.board_position || 0) - 1000;
+      } else {
+        const prevHidden = allColumn[firstVisibleIdx - 1];
+        newPosition = ((prevHidden?.board_position || 0) + (firstVisible.board_position || 0)) / 2;
+      }
+    } else if (destination.index >= visibleColumn.length) {
+      // After the last visible item — place after all items in the full list
+      const lastVisible = visibleColumn[visibleColumn.length - 1];
+      const lastVisibleIdx = allColumn.findIndex((p) => p.id === lastVisible.id);
+      if (lastVisibleIdx >= allColumn.length - 1) {
+        newPosition = (lastVisible.board_position || 0) + 1000;
+      } else {
+        const nextHidden = allColumn[lastVisibleIdx + 1];
+        newPosition = ((lastVisible.board_position || 0) + (nextHidden?.board_position || 0)) / 2;
+      }
     } else {
-      const prev = columnProjects[destination.index - 1];
-      const next = columnProjects[destination.index];
-      newPosition = ((prev?.board_position || 0) + (next?.board_position || 0)) / 2;
+      // Between two visible items — find a gap in the full list that avoids hidden items
+      const prev = visibleColumn[destination.index - 1];
+      const next = visibleColumn[destination.index];
+      const prevIdx = allColumn.findIndex((p) => p.id === prev.id);
+      const nextIdx = allColumn.findIndex((p) => p.id === next.id);
+      if (nextIdx - prevIdx === 1) {
+        // Adjacent in full list, simple midpoint
+        newPosition = ((prev?.board_position || 0) + (next?.board_position || 0)) / 2;
+      } else {
+        // Hidden items exist between them; place just after the prev item
+        const afterPrev = allColumn[prevIdx + 1];
+        newPosition = ((prev?.board_position || 0) + (afterPrev?.board_position || 0)) / 2;
+      }
     }
 
     if (source.droppableId !== destination.droppableId) {

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -12,10 +12,12 @@ const columns = [
 ];
 
 export function KanbanBoard() {
-  const { projects, updateBoardStatus, updateBoardPosition, fetchProjects } = useProjectsStore();
+  const { filteredProjects, updateBoardStatus, updateBoardPosition, fetchProjects } = useProjectsStore();
+
+  const visibleProjects = filteredProjects();
 
   const getProjectsForColumn = (columnId: string) =>
-    projects
+    visibleProjects
       .filter((p) => p.board_status === columnId)
       .sort((a, b) => (a.board_position || 0) - (b.board_position || 0));
 

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -12,12 +12,12 @@ const columns = [
 ];
 
 export function KanbanBoard() {
-  const { filteredProjects, updateBoardStatus, updateBoardPosition, fetchProjects } = useProjectsStore();
+  const { projects, filteredProjects, updateBoardStatus, updateBoardPosition, fetchProjects } = useProjectsStore();
 
   const visibleProjects = filteredProjects();
 
-  const getProjectsForColumn = (columnId: string) =>
-    visibleProjects
+  const getProjectsForColumn = (columnId: string, source = visibleProjects) =>
+    source
       .filter((p) => p.board_status === columnId)
       .sort((a, b) => (a.board_position || 0) - (b.board_position || 0));
 
@@ -30,7 +30,8 @@ export function KanbanBoard() {
       return;
     }
 
-    const columnProjects = getProjectsForColumn(destination.droppableId);
+    // Use ALL projects (not filtered) so positions don't collide with hidden items
+    const columnProjects = getProjectsForColumn(destination.droppableId, projects);
 
     // Fractional positioning: interpolate between siblings for stable reorder
     let newPosition: number;

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
-import { Plus } from '@phosphor-icons/react';
+import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
 import { KanbanBoard } from '../components/board/KanbanBoard';
 import { useProjectsStore } from '../store/projects';
 import { useUIStore } from '../store/ui';
 
+const priorities = [1, 2, 3, 4, 5];
+
 export default function BoardPage() {
-  const { projects, fetchProjects, subscribeToProjects, isLoading, selectProject } = useProjectsStore();
+  const { projects, fetchProjects, subscribeToProjects, isLoading, selectProject, searchQuery, setSearchQuery, filterPriority, setFilterPriority } = useProjectsStore();
   const openPanel = useUIStore((s) => s.openPanel);
 
   useEffect(() => {
@@ -26,13 +28,38 @@ export default function BoardPage() {
     <div className="h-full flex flex-col">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
         <h2 className="text-normal font-medium">Projects</h2>
-        <button
-          onClick={() => { selectProject('new'); openPanel(); }}
-          className="flex items-center gap-2 px-3 py-1.5 bg-brand text-white rounded-lg text-sm hover:bg-brand-hover transition-colors"
-        >
-          <Plus size={16} />
-          New Project
-        </button>
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <MagnifyingGlass size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-low" />
+            <input
+              type="text"
+              placeholder="Search projects..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="bg-muted border border-border rounded-lg pl-8 pr-3 py-1 text-xs text-normal placeholder:text-low focus:outline-none focus:ring-1 focus:ring-brand w-48"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-low text-xs">Priority:</label>
+            <select
+              value={filterPriority ?? ''}
+              onChange={(e) => setFilterPriority(e.target.value ? Number(e.target.value) : null)}
+              className="bg-muted border border-border rounded-lg px-3 py-1 text-xs text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+            >
+              <option value="">All</option>
+              {priorities.map((p) => (
+                <option key={p} value={p}>P{p}</option>
+              ))}
+            </select>
+          </div>
+          <button
+            onClick={() => { selectProject('new'); openPanel(); }}
+            className="flex items-center gap-2 px-3 py-1.5 bg-brand text-white rounded-lg text-sm hover:bg-brand-hover transition-colors"
+          >
+            <Plus size={16} />
+            New Project
+          </button>
+        </div>
       </div>
 
       {projects.length === 0 ? (

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -110,6 +110,10 @@ export default function ToolsPage() {
         <div className="flex items-center justify-center flex-1">
           <div className="text-low">Loading tools...</div>
         </div>
+      ) : tools.length > 0 && visibleTools.length === 0 ? (
+        <div className="flex items-center justify-center flex-1">
+          <div className="text-low">No matching tools</div>
+        </div>
       ) : (
         <div className="flex-1 overflow-auto">
           <ToolsGrid tools={visibleTools} />

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -1,11 +1,20 @@
-import { useEffect } from 'react';
-import { Plus } from '@phosphor-icons/react';
+import { useEffect, useMemo } from 'react';
+import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
 import { ToolsGrid } from '../components/tools/ToolsGrid';
 import { useToolsStore } from '../store/tools';
 import { useUIStore } from '../store/ui';
 
+const categories = ['using', 'to-check-out'];
+
 export default function ToolsPage() {
-  const { tools, fetchTools, subscribeToTools, isLoading, totalMonthlyCost, totalAnnualCost, activeToolCount, renewingWithin30Days, selectTool } = useToolsStore();
+  const {
+    tools, fetchTools, subscribeToTools, isLoading,
+    totalMonthlyCost, totalAnnualCost, activeToolCount, renewingWithin30Days,
+    selectTool, filteredTools,
+    searchQuery, setSearchQuery,
+    filterCategory, setFilterCategory,
+    filterPlatform, setFilterPlatform,
+  } = useToolsStore();
   const openPanel = useUIStore((s) => s.openPanel);
 
   useEffect(() => {
@@ -13,6 +22,14 @@ export default function ToolsPage() {
     const cleanup = subscribeToTools();
     return cleanup;
   }, [fetchTools, subscribeToTools]);
+
+  const availablePlatforms = useMemo(() => {
+    const platforms = new Set<string>();
+    tools.forEach((t) => t.platform?.forEach((p) => platforms.add(p)));
+    return Array.from(platforms).sort();
+  }, [tools]);
+
+  const visibleTools = filteredTools();
 
   return (
     <div className="h-full flex flex-col">
@@ -38,16 +55,54 @@ export default function ToolsPage() {
         </div>
       </div>
 
-      {/* Header */}
+      {/* Header with search and filters */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
         <h2 className="text-normal font-medium">AI Tools</h2>
-        <button
-          onClick={() => { selectTool('new'); openPanel(); }}
-          className="flex items-center gap-2 px-3 py-1.5 bg-brand text-white rounded-lg text-sm hover:bg-brand-hover transition-colors"
-        >
-          <Plus size={16} />
-          Add Tool
-        </button>
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <MagnifyingGlass size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-low" />
+            <input
+              type="text"
+              placeholder="Search tools..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="bg-muted border border-border rounded-lg pl-8 pr-3 py-1 text-xs text-normal placeholder:text-low focus:outline-none focus:ring-1 focus:ring-brand w-48"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-low text-xs">Category:</label>
+            <select
+              value={filterCategory || ''}
+              onChange={(e) => setFilterCategory(e.target.value || null)}
+              className="bg-muted border border-border rounded-lg px-3 py-1 text-xs text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+            >
+              <option value="">All</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-low text-xs">Platform:</label>
+            <select
+              value={filterPlatform || ''}
+              onChange={(e) => setFilterPlatform(e.target.value || null)}
+              className="bg-muted border border-border rounded-lg px-3 py-1 text-xs text-normal focus:outline-none focus:ring-1 focus:ring-brand"
+            >
+              <option value="">All</option>
+              {availablePlatforms.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </div>
+          <button
+            onClick={() => { selectTool('new'); openPanel(); }}
+            className="flex items-center gap-2 px-3 py-1.5 bg-brand text-white rounded-lg text-sm hover:bg-brand-hover transition-colors"
+          >
+            <Plus size={16} />
+            Add Tool
+          </button>
+        </div>
       </div>
 
       {/* Tools Grid */}
@@ -57,7 +112,7 @@ export default function ToolsPage() {
         </div>
       ) : (
         <div className="flex-1 overflow-auto">
-          <ToolsGrid tools={tools} />
+          <ToolsGrid tools={visibleTools} />
         </div>
       )}
     </div>

--- a/src/store/__tests__/projects.test.ts
+++ b/src/store/__tests__/projects.test.ts
@@ -290,6 +290,72 @@ describe('useProjectsStore', () => {
     });
   });
 
+  // ── filteredProjects ───────────────────────────────────────────────────────
+
+  describe('filteredProjects', () => {
+    const projectA = makeProject({ id: 'p1', name: 'Alpha', description: 'First project', priority: 1 });
+    const projectB = makeProject({ id: 'p2', name: 'Beta', description: 'Second project', priority: 2 });
+    const projectC = makeProject({ id: 'p3', name: 'Gamma', description: 'Alpha related', priority: 1 });
+
+    beforeEach(() => {
+      useProjectsStore.setState({ projects: [projectA, projectB, projectC], searchQuery: '', filterPriority: null });
+    });
+
+    it('returns all projects when no filters are set', () => {
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectA, projectB, projectC]);
+    });
+
+    it('filters by search query matching name', () => {
+      useProjectsStore.setState({ searchQuery: 'beta' });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectB]);
+    });
+
+    it('filters by search query matching description', () => {
+      useProjectsStore.setState({ searchQuery: 'second' });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectB]);
+    });
+
+    it('search is case-insensitive', () => {
+      useProjectsStore.setState({ searchQuery: 'BETA' });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectB]);
+    });
+
+    it('filters by priority', () => {
+      useProjectsStore.setState({ filterPriority: 1 });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectA, projectC]);
+    });
+
+    it('composes search and priority filters', () => {
+      useProjectsStore.setState({ searchQuery: 'gamma', filterPriority: 1 });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectC]);
+    });
+
+    it('returns empty array when nothing matches', () => {
+      useProjectsStore.setState({ searchQuery: 'nonexistent' });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([]);
+    });
+
+    it('returns all projects when filterPriority is null', () => {
+      useProjectsStore.setState({ filterPriority: null });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectA, projectB, projectC]);
+    });
+
+    it('skips projects with null description during search', () => {
+      const noDesc = makeProject({ id: 'p4', name: 'Delta', description: null, priority: 3 });
+      useProjectsStore.setState({ projects: [projectA, noDesc], searchQuery: 'first' });
+      const result = useProjectsStore.getState().filteredProjects();
+      expect(result).toEqual([projectA]);
+    });
+  });
+
   // ── clearError ─────────────────────────────────────────────────────────────
 
   describe('clearError', () => {

--- a/src/store/__tests__/tools.test.ts
+++ b/src/store/__tests__/tools.test.ts
@@ -321,6 +321,72 @@ describe('useToolsStore', () => {
     });
   });
 
+  // ── filteredTools ──────────────────────────────────────────────────────────
+
+  describe('filteredTools', () => {
+    const toolA = makeTool({ id: 't1', name: 'Claude Pro', category: 'using', platform: ['web', 'api'] });
+    const toolB = makeTool({ id: 't2', name: 'Cursor', category: 'using', platform: ['desktop'] });
+    const toolC = makeTool({ id: 't3', name: 'Windsurf', category: 'to-check-out', platform: ['desktop', 'web'] });
+
+    beforeEach(() => {
+      useToolsStore.setState({ tools: [toolA, toolB, toolC], searchQuery: '', filterCategory: null, filterPlatform: null });
+    });
+
+    it('returns all tools when no filters are set', () => {
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolA, toolB, toolC]);
+    });
+
+    it('filters by search query matching name', () => {
+      useToolsStore.setState({ searchQuery: 'claude' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolA]);
+    });
+
+    it('search is case-insensitive', () => {
+      useToolsStore.setState({ searchQuery: 'CURSOR' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolB]);
+    });
+
+    it('filters by category', () => {
+      useToolsStore.setState({ filterCategory: 'to-check-out' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolC]);
+    });
+
+    it('filters by platform', () => {
+      useToolsStore.setState({ filterPlatform: 'api' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolA]);
+    });
+
+    it('composes search, category, and platform filters', () => {
+      useToolsStore.setState({ searchQuery: 'wind', filterCategory: 'to-check-out', filterPlatform: 'web' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolC]);
+    });
+
+    it('returns empty array when nothing matches', () => {
+      useToolsStore.setState({ searchQuery: 'nonexistent' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([]);
+    });
+
+    it('returns all tools when filters are null/empty', () => {
+      useToolsStore.setState({ searchQuery: '', filterCategory: null, filterPlatform: null });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolA, toolB, toolC]);
+    });
+
+    it('handles tools with null platform during platform filter', () => {
+      const noPlatform = makeTool({ id: 't4', name: 'NoPlatform', category: 'using', platform: null });
+      useToolsStore.setState({ tools: [toolA, noPlatform], filterPlatform: 'web' });
+      const result = useToolsStore.getState().filteredTools();
+      expect(result).toEqual([toolA]);
+    });
+  });
+
   // ── clearError ─────────────────────────────────────────────────────────────
 
   describe('clearError', () => {

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -15,6 +15,8 @@ interface ProjectsState {
   boardColumns: string[];
   isLoading: boolean;
   error: string | null;
+  searchQuery: string;
+  filterPriority: number | null;
   fetchProjects: () => Promise<void>;
   subscribeToProjects: () => () => void;
   createProject: (project: ProjectInsert) => Promise<ProjectRow | null>;
@@ -24,6 +26,9 @@ interface ProjectsState {
   updateBoardPosition: (id: string, position: number) => Promise<ProjectRow | null>;
   selectProject: (id: string | null) => void;
   clearError: () => void;
+  setSearchQuery: (query: string) => void;
+  setFilterPriority: (priority: number | null) => void;
+  filteredProjects: () => ProjectRow[];
 }
 
 const boardColumns = ['idea', 'todo', 'in-progress', 'paused', 'done'];
@@ -67,6 +72,8 @@ export const useProjectsStore = create<ProjectsState>()(
     boardColumns,
     isLoading: false,
     error: null,
+    searchQuery: '',
+    filterPriority: null,
 
     fetchProjects: async () => {
       set({ isLoading: true, error: null }, false, 'projects/fetchProjects:start');
@@ -201,5 +208,29 @@ export const useProjectsStore = create<ProjectsState>()(
       ),
 
     clearError: () => set({ error: null }, false, 'projects/clearError'),
+
+    setSearchQuery: (query) => set({ searchQuery: query }, false, 'projects/setSearchQuery'),
+
+    setFilterPriority: (priority) => set({ filterPriority: priority }, false, 'projects/setFilterPriority'),
+
+    filteredProjects: () => {
+      const { projects, searchQuery, filterPriority } = get();
+      let filtered = projects;
+
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        filtered = filtered.filter(
+          (p) =>
+            p.name.toLowerCase().includes(q) ||
+            (p.description && p.description.toLowerCase().includes(q)),
+        );
+      }
+
+      if (filterPriority !== null) {
+        filtered = filtered.filter((p) => p.priority === filterPriority);
+      }
+
+      return filtered;
+    },
   }), { name: 'projects-store' }),
 );

--- a/src/store/tools.ts
+++ b/src/store/tools.ts
@@ -15,6 +15,9 @@ interface ToolsState {
   selectedTool: ToolRow | null;
   isLoading: boolean;
   error: string | null;
+  searchQuery: string;
+  filterCategory: string | null;
+  filterPlatform: string | null;
   fetchTools: () => Promise<void>;
   subscribeToTools: () => () => void;
   createTool: (tool: ToolInsert) => Promise<ToolRow | null>;
@@ -22,6 +25,10 @@ interface ToolsState {
   deleteTool: (id: string) => Promise<boolean>;
   selectTool: (id: string | null) => void;
   clearError: () => void;
+  setSearchQuery: (query: string) => void;
+  setFilterCategory: (category: string | null) => void;
+  setFilterPlatform: (platform: string | null) => void;
+  filteredTools: () => ToolRow[];
   totalMonthlyCost: () => number;
   totalAnnualCost: () => number;
   activeToolCount: () => number;
@@ -68,6 +75,9 @@ export const useToolsStore = create<ToolsState>()(
       selectedTool: null,
       isLoading: false,
       error: null,
+      searchQuery: '',
+      filterCategory: null,
+      filterPlatform: null,
 
       fetchTools: async () => {
         set({ isLoading: true, error: null }, false, 'tools/fetchTools:start');
@@ -196,6 +206,32 @@ export const useToolsStore = create<ToolsState>()(
         ),
 
       clearError: () => set({ error: null }, false, 'tools/clearError'),
+
+      setSearchQuery: (query) => set({ searchQuery: query }, false, 'tools/setSearchQuery'),
+
+      setFilterCategory: (category) => set({ filterCategory: category }, false, 'tools/setFilterCategory'),
+
+      setFilterPlatform: (platform) => set({ filterPlatform: platform }, false, 'tools/setFilterPlatform'),
+
+      filteredTools: () => {
+        const { tools, searchQuery, filterCategory, filterPlatform } = get();
+        let filtered = tools;
+
+        if (searchQuery) {
+          const q = searchQuery.toLowerCase();
+          filtered = filtered.filter((t) => t.name.toLowerCase().includes(q));
+        }
+
+        if (filterCategory) {
+          filtered = filtered.filter((t) => t.category === filterCategory);
+        }
+
+        if (filterPlatform) {
+          filtered = filtered.filter((t) => t.platform?.includes(filterPlatform));
+        }
+
+        return filtered;
+      },
 
       totalMonthlyCost: () =>
         get()


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- **Board view**: Added text search over project name/description and a priority filter dropdown (P1–P5). The KanbanBoard now uses filtered results, so only matching projects appear across all columns.
- **Tools view**: Added text search by tool name, category filter (`using` / `to-check-out`), and platform filter (dynamically populated from existing tool data).
- Filter state lives in the respective Zustand stores (`useProjectsStore`, `useToolsStore`) and filtering is done client-side for instant feedback. The UI pattern reuses the same select/input styling from the AgentsPage filters.

Closes [ENG-7](https://linear.app/alecv/issue/ENG-7/add-search-and-filtering-to-board-and-tools-views)

### Updates since last revision

Addressed Devin Review and Copilot feedback:

- **Fix: DnD position calculation with hidden projects** — The `onDragEnd` handler now uses two separate helpers: `getProjectsForColumn` (filtered, for rendering and DnD index lookup) and `getAllProjectsForColumn` (full list, for collision avoidance). Since `destination.index` from `@hello-pangea/dnd` is relative to the rendered/filtered list, the handler identifies intended neighbor projects from the visible list, then consults the full list to find a gap that doesn't collide with hidden items.
- **Fix: Incorrect empty state on Tools page** — When filters yield zero matches but tools exist, the page now shows "No matching tools" instead of the misleading "No tools yet" / "Add your first AI tool subscription" empty state.
- **Added unit tests** for `filteredProjects` (9 cases) and `filteredTools` (9 cases) covering search, individual filters, filter composition, null/empty handling, and edge cases.

## Review & Testing Checklist for Human

- [ ] **Drag-and-drop while filters are active (Board)**: Apply a search or priority filter that hides some projects, then drag a card to a new position or column. Clear the filter and verify no projects share the same position or appear in unexpected order. Pay special attention to dragging between two visible items that have hidden items between them in the full list.
- [ ] **Drag-and-drop edge cases**: Test dragging to the first position and last position in a filtered column where hidden items exist before/after the visible items. Verify positions are correct after clearing filters.
- [ ] **Filtered-empty state (Tools)**: Apply filters that match zero tools and confirm "No matching tools" appears (not "No tools yet"). Clear filters and confirm all tools reappear.
- [ ] **Filter composition**: On both Board and Tools views, apply multiple filters simultaneously and verify they compose correctly (AND logic). Clear individual filters and verify results update.

### Notes

- The DnD position logic is the most complex part of this PR and was iterated on multiple times to handle the index mismatch between filtered/rendered indices and unfiltered list positions. It has not been unit tested directly (lives in a React component), so manual testing of drag-and-drop with active filters is important.
- All 119 tests pass; lint is clean.

Link to Devin session: https://app.devin.ai/sessions/e0e01c0a824a45ca89032ee74d629aad
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
