### PR TITLE
Clean up stray muninn/ directory and empty types/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist-ssr
 *.local
 .env
 
+# Stray nested repo (leftover from clone / submodule)
+muninn/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/agents/SessionCard.tsx
+++ b/src/components/agents/SessionCard.tsx
@@ -1,10 +1,8 @@
 import { useNavigate } from 'react-router';
 import { useProjectsStore } from '../../store/projects';
 import { useUIStore } from '../../store/ui';
-import type { Database } from '../../database.types';
+import type { SessionRow } from '../../types';
 import { Desktop, Clock } from '@phosphor-icons/react';
-
-type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
 
 interface SessionCardProps {
   session: SessionRow;

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -1,8 +1,6 @@
 import { Droppable } from '@hello-pangea/dnd';
 import type { ReactNode } from 'react';
-import type { Database } from '../../database.types';
-
-type ProjectRow = Database['public']['Tables']['projects']['Row'];
+import type { ProjectRow } from '../../types';
 
 interface KanbanColumnProps {
   id: string;

--- a/src/components/board/ProjectCard.tsx
+++ b/src/components/board/ProjectCard.tsx
@@ -1,9 +1,7 @@
 import { Draggable } from '@hello-pangea/dnd';
 import { useProjectsStore } from '../../store/projects';
 import { useUIStore } from '../../store/ui';
-import type { Database } from '../../database.types';
-
-type ProjectRow = Database['public']['Tables']['projects']['Row'];
+import type { ProjectRow } from '../../types';
 
 interface ProjectCardProps {
   project: ProjectRow;

--- a/src/components/detail/ProjectDetail.tsx
+++ b/src/components/detail/ProjectDetail.tsx
@@ -11,11 +11,7 @@ import {
 import { useProjectsStore } from '../../store/projects';
 import { useUIStore } from '../../store/ui';
 import { supabase } from '../../lib/supabase';
-import type { Database } from '../../database.types';
-
-type ProjectRow = Database['public']['Tables']['projects']['Row'];
-type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
-type MemoryRow = Database['public']['Tables']['memories']['Row'];
+import type { ProjectRow, SessionRow, MemoryRow } from '../../types';
 
 const STATUS_OPTIONS = ['idea', 'todo', 'in-progress', 'paused', 'done'] as const;
 

--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -1,7 +1,7 @@
 import { useToolsStore } from '../../store/tools';
 import { useUIStore } from '../../store/ui';
 import { isWithin30Days } from '../../lib/dates';
-import type { Database } from '../../database.types';
+import type { ToolRow } from '../../types';
 import {
   Desktop,
   Globe,
@@ -9,8 +9,6 @@ import {
   AppleLogo,
   LinuxLogo,
 } from '@phosphor-icons/react';
-
-type ToolRow = Database['public']['Tables']['tools']['Row'];
 
 interface ToolCardProps {
   tool: ToolRow;

--- a/src/components/tools/ToolsGrid.tsx
+++ b/src/components/tools/ToolsGrid.tsx
@@ -1,7 +1,5 @@
 import { ToolCard } from './ToolCard';
-import type { Database } from '../../database.types';
-
-type ToolRow = Database['public']['Tables']['tools']['Row'];
+import type { ToolRow } from '../../types';
 
 interface ToolsGridProps {
   tools: ToolRow[];

--- a/src/store/__tests__/projects.test.ts
+++ b/src/store/__tests__/projects.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useProjectsStore } from '../projects';
 import { setMockResult, resetMockResult, supabaseMock } from '../../test/setup';
-import type { Database } from '../../database.types';
-
-type ProjectRow = Database['public']['Tables']['projects']['Row'];
+import type { ProjectRow } from '../../types';
 
 const makeProject = (overrides: Partial<ProjectRow> = {}): ProjectRow => ({
   id: 'proj-1',

--- a/src/store/__tests__/sessions.test.ts
+++ b/src/store/__tests__/sessions.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useSessionsStore } from '../sessions';
 import { setMockResult, resetMockResult, supabaseMock } from '../../test/setup';
-import type { Database } from '../../database.types';
-
-type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
+import type { SessionRow } from '../../types';
 
 const makeSession = (overrides: Partial<SessionRow> = {}): SessionRow => ({
   id: 'sess-1',

--- a/src/store/__tests__/tools.test.ts
+++ b/src/store/__tests__/tools.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { useToolsStore } from '../tools';
 import { setMockResult, resetMockResult, supabaseMock } from '../../test/setup';
-import type { Database } from '../../database.types';
-
-type ToolRow = Database['public']['Tables']['tools']['Row'];
+import type { ToolRow } from '../../types';
 
 const makeTool = (overrides: Partial<ToolRow> = {}): ToolRow => ({
   id: 'tool-1',

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -2,11 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
-import type { Database } from '../database.types';
-
-type ProjectRow = Database['public']['Tables']['projects']['Row'];
-type ProjectInsert = Database['public']['Tables']['projects']['Insert'];
-type ProjectUpdate = Database['public']['Tables']['projects']['Update'];
+import type { ProjectRow, ProjectInsert, ProjectUpdate } from '../types';
 
 interface ProjectsState {
   projects: ProjectRow[];

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -1,9 +1,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { supabase } from '../lib/supabase';
-import type { Database } from '../database.types';
-
-type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
+import type { SessionRow } from '../types';
 
 const PAGE_SIZE = 25;
 

--- a/src/store/tools.ts
+++ b/src/store/tools.ts
@@ -3,11 +3,7 @@ import { devtools } from 'zustand/middleware';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 import { isWithin30Days } from '../lib/dates';
-import type { Database } from '../database.types';
-
-type ToolRow = Database['public']['Tables']['tools']['Row'];
-type ToolInsert = Database['public']['Tables']['tools']['Insert'];
-type ToolUpdate = Database['public']['Tables']['tools']['Update'];
+import type { ToolRow, ToolInsert, ToolUpdate } from '../types';
 
 interface ToolsState {
   tools: ToolRow[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,15 @@
+import type { Database } from '../database.types';
+
+// Row types (read)
+export type ProjectRow = Database['public']['Tables']['projects']['Row'];
+export type ToolRow = Database['public']['Tables']['tools']['Row'];
+export type SessionRow = Database['public']['Tables']['agent_sessions']['Row'];
+export type MemoryRow = Database['public']['Tables']['memories']['Row'];
+
+// Insert types (create)
+export type ProjectInsert = Database['public']['Tables']['projects']['Insert'];
+export type ToolInsert = Database['public']['Tables']['tools']['Insert'];
+
+// Update types (patch)
+export type ProjectUpdate = Database['public']['Tables']['projects']['Update'];
+export type ToolUpdate = Database['public']['Tables']['tools']['Update'];


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- **Added `muninn/` to `.gitignore`** — prevents the stray nested repo (leftover from a botched clone/submodule) from ever being tracked
- **Populated `src/types/` with shared type aliases** — replaced the empty `.gitkeep` with `src/types/index.ts` exporting `ProjectRow`, `ToolRow`, `SessionRow`, `MemoryRow`, and their `Insert`/`Update` variants
- **Deduplicated 13 inline type definitions across 10 files** — all stores, components, and tests now import from `src/types/` instead of re-deriving from `Database['public']['Tables']`

## Testing

- TypeScript compiles cleanly (`tsc -b`)
- All 119 tests pass (`vitest run`)
- ESLint passes with no warnings

Closes [ENG-11](https://linear.app/alecv/issue/ENG-11/clean-up-stray-muninn-directory-and-empty-types-folder)

---
> **Tip:** I will respond to comments that @ mention @byrus-cyrus on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
