### PR TITLE
Add Trial category to tools (ENG-25)

### DIFF
--- a/src/components/detail/ToolDetail.tsx
+++ b/src/components/detail/ToolDetail.tsx
@@ -7,7 +7,7 @@ const platforms = ['mac', 'linux', 'windows', 'web', 'ios', 'android'];
 
 type ToolFormData = {
   name: string;
-  category: 'using' | 'to-check-out' | 'not-using' | 'watching';
+  category: 'using' | 'to-check-out' | 'not-using' | 'watching' | 'trial';
   active_subscription: boolean;
   cost: number;
   billing_cycle: 'monthly' | 'annual' | 'one-time';
@@ -179,11 +179,26 @@ export function ToolDetail() {
           className="w-full bg-muted border border-border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 focus:ring-brand"
         >
           <option value="using">Using</option>
+          <option value="trial">Trial</option>
           <option value="to-check-out">To Check Out</option>
           <option value="not-using">Not Using</option>
           <option value="watching">Watching</option>
         </select>
       </div>
+
+      {formData.category === 'trial' && (
+        <div>
+          <label htmlFor="tool-trial-end" className="text-low text-xs block mb-1">Trial End Date</label>
+          <input
+            id="tool-trial-end"
+            type="date"
+            value={formData.renewal_date}
+            onChange={(e) => setFormData({ ...formData, renewal_date: e.target.value })}
+            className="w-full bg-muted border border-border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 focus:ring-brand"
+          />
+          <p className="mt-1 text-[11px] text-low">When the trial period ends (billing may start)</p>
+        </div>
+      )}
 
       <div>
         <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -51,6 +51,8 @@ export function ToolCard({ tool }: ToolCardProps) {
         return { label: 'To Check Out', className: 'bg-category-to-check-out/20 text-category-to-check-out' };
       case 'not-using':
         return { label: 'Not Using', className: 'bg-category-not-using/20 text-category-not-using' };
+      case 'trial':
+        return { label: 'Trial', className: 'bg-category-trial/20 text-category-trial' };
       case 'watching':
         return { label: 'Watching', className: 'bg-category-watching/20 text-category-watching' };
       default:
@@ -81,7 +83,18 @@ export function ToolCard({ tool }: ToolCardProps) {
 
       <div className="flex items-center gap-2 mb-3">
         {costDisplay && <span className="text-brand font-medium">{costDisplay}</span>}
-        {tool.active_subscription && nextRenewal && (
+        {tool.category === 'trial' && nextRenewal && (
+          <span className={`text-xs ${isRenewingSoon ? 'text-warning' : 'text-low'}`}>
+            Trial ends {nextRenewal.toLocaleDateString()}
+            {isRenewingSoon && (
+              <>
+                {' '}<span aria-hidden="true">{'\u26A0\uFE0F'}</span>
+                <span className="sr-only"> (trial ending soon)</span>
+              </>
+            )}
+          </span>
+        )}
+        {tool.category !== 'trial' && tool.active_subscription && nextRenewal && (
           <span className={`text-xs ${isRenewingSoon ? 'text-warning' : 'text-low'}`}>
             Renews {nextRenewal.toLocaleDateString()}
             {isRenewingSoon && (

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@
     --category-watching: 0 0% 50%;
     --category-not-using: 0 0% 40%;
     --category-to-check-out: 0 0% 50%;
+    --category-trial: 210 60% 55%;
   }
 
   [data-theme='light'] {
@@ -56,6 +57,7 @@
     --category-watching: 0 0% 45%;
     --category-not-using: 0 0% 40%;
     --category-to-check-out: 0 0% 45%;
+    --category-trial: 210 55% 48%;
   }
 
   html,

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -4,7 +4,7 @@ import { ToolsGrid } from '../components/tools/ToolsGrid';
 import { useToolsStore } from '../store/tools';
 import { useUIStore } from '../store/ui';
 
-const categories = ['using', 'to-check-out', 'not-using', 'watching'];
+const categories = ['using', 'trial', 'to-check-out', 'not-using', 'watching'];
 
 export default function ToolsPage() {
   const {
@@ -48,7 +48,7 @@ export default function ToolsPage() {
           <div className="text-normal font-medium">{activeToolCount()}</div>
         </div>
         <div className="bg-muted rounded-lg p-3">
-          <div className="text-low text-xs mb-1">Renewing Soon</div>
+          <div className="text-low text-xs mb-1">Expiring Soon</div>
           <div className={`font-medium ${renewingWithin30Days() > 0 ? 'text-warning' : 'text-normal'}`}>
             {renewingWithin30Days()}
           </div>

--- a/src/store/tools.ts
+++ b/src/store/tools.ts
@@ -241,7 +241,9 @@ export const useToolsStore = create<ToolsState>()(
 
       activeToolCount: () => get().tools.filter((tool) => tool.category === 'using').length,
 
-      renewingWithin30Days: () => get().tools.filter((tool) => tool.active_subscription && isWithin30Days(nextRenewalDate(tool))).length,
+      renewingWithin30Days: () => get().tools.filter((tool) =>
+        (tool.active_subscription || tool.category === 'trial') && isWithin30Days(nextRenewalDate(tool)),
+      ).length,
     }),
     { name: 'tools-store' },
   ),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ export default {
         'category-watching': 'hsl(var(--category-watching) / <alpha-value>)',
         'category-not-using': 'hsl(var(--category-not-using) / <alpha-value>)',
         'category-to-check-out': 'hsl(var(--category-to-check-out) / <alpha-value>)',
+        'category-trial': 'hsl(var(--category-trial) / <alpha-value>)',
       },
       fontFamily: {
         sans: ['IBM Plex Sans', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Adds a new **Trial** tool category with a dedicated "Trial End Date" date picker, shown independently of the Active Subscription toggle
- Trial tools display "Trial ends [date]" with the same 30-day warning logic as renewals
- Trial tools count toward the **Expiring Soon** stat (renamed from "Renewing Soon" to cover both cases)
- Blue badge styling for trial category in both light and dark themes

## Changes

| File | What changed |
|------|-------------|
| `src/index.css` | Added `--category-trial` CSS variable (dark + light) |
| `tailwind.config.js` | Added `category-trial` Tailwind color |
| `src/pages/ToolsPage.tsx` | Added `trial` to categories array, renamed stat label to "Expiring Soon" |
| `src/components/detail/ToolDetail.tsx` | Added `trial` to type union + dropdown, added Trial End Date field |
| `src/components/tools/ToolCard.tsx` | Added trial badge case, trial-specific "Trial ends" warning text |
| `src/store/tools.ts` | Updated `renewingWithin30Days` to include trial tools |

## Test plan

- [ ] Create a new tool with category "Trial" — verify Trial End Date field appears
- [ ] Set a trial end date within 30 days — verify warning icon and "Expiring Soon" count
- [ ] Set a trial end date > 30 days out — verify no warning shown
- [ ] Verify existing subscription renewal warnings still work correctly
- [ ] Check trial badge renders with blue color in both dark and light themes
- [ ] Filter tools by "trial" category in the dropdown

Closes [ENG-25](https://linear.app/alecv/issue/ENG-25/add-trial-category-to-tools)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
