### PR TITLE
Add realtime subscription for agent sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muninn",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muninn",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@phosphor-icons/react": "^2.1.10",

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -6,6 +6,7 @@ export default function AgentsPage() {
   const {
     fetchSessions,
     fetchFilterOptions,
+    subscribeToSessions,
     availableInterfaces,
     availableMachines,
     filterInterface,
@@ -17,7 +18,8 @@ export default function AgentsPage() {
   useEffect(() => {
     void fetchSessions();
     void fetchFilterOptions();
-  }, [fetchSessions, fetchFilterOptions]);
+    return subscribeToSessions();
+  }, [fetchSessions, fetchFilterOptions, subscribeToSessions]);
 
   return (
     <div className="h-full flex flex-col">

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 import type { SessionRow } from '../types';
 
@@ -19,11 +20,41 @@ interface SessionsState {
   fetchSessions: () => Promise<void>;
   fetchMoreSessions: () => Promise<void>;
   fetchFilterOptions: () => Promise<void>;
+  subscribeToSessions: () => () => void;
   clearError: () => void;
   setFilterInterface: (filter: string | null) => void;
   setFilterMachine: (filter: string | null) => void;
   setFilterProject: (filter: string | null) => void;
 }
+
+interface RealtimeSubscriptionState {
+  channel: RealtimeChannel | null;
+  subscriberCount: number;
+}
+
+type RealtimeRegistry = Record<string, RealtimeSubscriptionState>;
+type GlobalRealtimeRegistry = typeof globalThis & {
+  __muninnRealtimeRegistry__?: RealtimeRegistry;
+};
+
+const getRealtimeRegistry = (): RealtimeRegistry => {
+  const globalRef = globalThis as GlobalRealtimeRegistry;
+  if (!globalRef.__muninnRealtimeRegistry__) {
+    globalRef.__muninnRealtimeRegistry__ = {};
+  }
+  return globalRef.__muninnRealtimeRegistry__;
+};
+
+const getSessionsSubscriptionState = (): RealtimeSubscriptionState => {
+  const registry = getRealtimeRegistry();
+  if (!registry.sessions) {
+    registry.sessions = {
+      channel: null,
+      subscriberCount: 0,
+    };
+  }
+  return registry.sessions;
+};
 
 export const useSessionsStore = create<SessionsState>()(
   devtools((set, get) => ({
@@ -98,6 +129,36 @@ export const useSessionsStore = create<SessionsState>()(
       const interfaces = [...new Set(data.map((r) => r.interface).filter(Boolean))] as string[];
       const machines = [...new Set(data.map((r) => r.machine).filter(Boolean))] as string[];
       set({ availableInterfaces: interfaces.sort(), availableMachines: machines.sort() }, false, 'sessions/filterOptions');
+    },
+
+    subscribeToSessions: () => {
+      const subscription = getSessionsSubscriptionState();
+      subscription.subscriberCount += 1;
+
+      if (!subscription.channel) {
+        subscription.channel = supabase
+          .channel('muninn-sessions')
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'agent_sessions' }, () => {
+            void get().fetchSessions();
+            void get().fetchFilterOptions();
+          })
+          .subscribe();
+      }
+
+      let hasCleanedUp = false;
+      return () => {
+        if (hasCleanedUp) return;
+        hasCleanedUp = true;
+
+        const currentSubscription = getSessionsSubscriptionState();
+        currentSubscription.subscriberCount = Math.max(0, currentSubscription.subscriberCount - 1);
+
+        if (currentSubscription.subscriberCount > 0 || !currentSubscription.channel) return;
+
+        const channel = currentSubscription.channel;
+        currentSubscription.channel = null;
+        void supabase.removeChannel(channel);
+      };
     },
 
     clearError: () => set({ error: null }, false, 'sessions/clearError'),


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Adds `subscribeToSessions` method to the sessions Zustand store using the same global registry pattern (reference-counted `RealtimeChannel` on `globalThis.__muninnRealtimeRegistry__`) already used by `projects.ts` and `tools.ts`
- Wires the subscription into `AgentsPage.tsx`'s `useEffect` so the Agents view receives live updates when agent sessions are created or modified from other machines
- On any `postgres_changes` event on `agent_sessions`, both `fetchSessions` and `fetchFilterOptions` are re-invoked so the feed and filter dropdowns stay in sync

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 135/135 tests pass
- [ ] Manual: open Agents page, trigger a session insert from another machine/interface, verify the feed updates without page reload
- [ ] Manual: verify cleanup — navigate away from Agents page and confirm channel is removed (no lingering subscriptions)

Closes ENG-18 — [Linear](https://linear.app/alecv/issue/ENG-18/add-realtime-subscription-for-agent-sessions)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
