### PR TITLE
Fix tags input to allow commas and spaces

### DIFF
--- a/src/components/detail/ToolDetail.tsx
+++ b/src/components/detail/ToolDetail.tsx
@@ -61,6 +61,7 @@ export function ToolDetail() {
   );
 
   const [formData, setFormData] = useState<ToolFormData>(initialFormData);
+  const [tagsDraft, setTagsDraft] = useState(initialFormData.tags.join(', '));
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errors, setErrors] = useState<{ name?: string; url?: string }>({});
@@ -306,8 +307,12 @@ export function ToolDetail() {
         <input
           id="tool-tags"
           type="text"
-          value={formData.tags.join(', ')}
-          onChange={(e) => setFormData({ ...formData, tags: e.target.value.split(',').map((t) => t.trim()).filter(Boolean) })}
+          value={tagsDraft}
+          onChange={(e) => setTagsDraft(e.target.value)}
+          onBlur={() => setFormData({ ...formData, tags: tagsDraft.split(',').map((t) => t.trim()).filter(Boolean) })}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') setFormData({ ...formData, tags: tagsDraft.split(',').map((t) => t.trim()).filter(Boolean) });
+          }}
           className="w-full bg-muted border border-border rounded-lg px-3 py-2 text-normal text-sm focus:outline-none focus:ring-1 focus:ring-brand"
           placeholder="AI, productivity, writing"
         />


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

The tags field in `ToolDetail` was splitting and trimming input on every keystroke via `onChange`, which immediately consumed commas and spaces — making it impossible to type multi-word or comma-separated tags.

**Root cause:** The `onChange` handler ran `value.split(',').map(t => t.trim()).filter(Boolean)` on every keystroke, then re-joined for display. Typing a comma would split, filter the empty trailing string, and collapse back without it.

**Fix:** Introduce a local `tagsDraft` string state for the raw input text. The draft is only parsed into the `formData.tags` array on `onBlur` or `Enter` — matching the pattern already used by `TechStackEditor` in `ProjectDetail.tsx`.

## Changes

- Added `tagsDraft` state to hold raw input text
- Changed `value` to read from `tagsDraft` instead of `formData.tags.join(', ')`
- Changed `onChange` to update `tagsDraft` (no parsing)
- Added `onBlur` and `onKeyDown` (Enter) to commit parsed tags to `formData`

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes (no warnings/errors)
- [x] All 135 existing tests pass
- [x] Build succeeds

Closes ENG-24
Resolves https://linear.app/alecv/issue/ENG-24/fix-tags-field-of-tools

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
