### PR TITLE
Optimize fetchFilterOptions with server-side distinct RPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muninn",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muninn",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@phosphor-icons/react": "^2.1.10",

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -253,7 +253,12 @@ export interface Database {
       };
     };
     Views: Record<string, never>;
-    Functions: Record<string, never>;
+    Functions: {
+      get_session_filter_options: {
+        Args: Record<string, never>;
+        Returns: { kind: string; value: string }[];
+      };
+    };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;
   };

--- a/src/store/__tests__/sessions.test.ts
+++ b/src/store/__tests__/sessions.test.ts
@@ -168,12 +168,13 @@ describe('useSessionsStore', () => {
   // ── fetchFilterOptions ─────────────────────────────────────────────────────
 
   describe('fetchFilterOptions', () => {
-    it('extracts unique interface and machine values', async () => {
+    it('extracts unique interface and machine values from RPC', async () => {
       setMockResult({
         data: [
-          { interface: 'claude-code', machine: 'midgard' },
-          { interface: 'claude.ai', machine: 'midgard' },
-          { interface: 'claude-code', machine: 'yggdrasil' },
+          { kind: 'interface', value: 'claude-code' },
+          { kind: 'interface', value: 'claude.ai' },
+          { kind: 'machine', value: 'midgard' },
+          { kind: 'machine', value: 'yggdrasil' },
         ],
       });
 
@@ -182,19 +183,6 @@ describe('useSessionsStore', () => {
       const state = useSessionsStore.getState();
       expect(state.availableInterfaces).toEqual(['claude-code', 'claude.ai']);
       expect(state.availableMachines).toEqual(['midgard', 'yggdrasil']);
-    });
-
-    it('filters out null values', async () => {
-      setMockResult({
-        data: [
-          { interface: 'claude-code', machine: null },
-          { interface: 'claude.ai', machine: 'midgard' },
-        ],
-      });
-
-      await useSessionsStore.getState().fetchFilterOptions();
-
-      expect(useSessionsStore.getState().availableMachines).toEqual(['midgard']);
     });
 
     it('handles null data gracefully', async () => {

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -91,12 +91,14 @@ export const useSessionsStore = create<SessionsState>()(
     },
 
     fetchFilterOptions: async () => {
-      const { data } = await supabase
-        .from('agent_sessions')
-        .select('interface, machine');
+      const { data } = await supabase.rpc('get_session_filter_options');
       if (!data) return;
-      const interfaces = [...new Set(data.map((r) => r.interface).filter(Boolean))] as string[];
-      const machines = [...new Set(data.map((r) => r.machine).filter(Boolean))] as string[];
+      const interfaces: string[] = [];
+      const machines: string[] = [];
+      for (const row of data) {
+        if (row.kind === 'interface') interfaces.push(row.value);
+        else if (row.kind === 'machine') machines.push(row.value);
+      }
       set({ availableInterfaces: interfaces.sort(), availableMachines: machines.sort() }, false, 'sessions/filterOptions');
     },
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -66,8 +66,11 @@ const channelMock = {
   unsubscribe: vi.fn(),
 };
 
+const rpcBuilder = createQueryBuilder();
+
 export const supabaseMock = {
   from: vi.fn(() => queryBuilder),
+  rpc: vi.fn(() => rpcBuilder),
   channel: vi.fn(() => channelMock),
   removeChannel: vi.fn(),
   __channelMock: channelMock,

--- a/supabase/migrations/20260418_add_get_session_filter_options.sql
+++ b/supabase/migrations/20260418_add_get_session_filter_options.sql
@@ -1,0 +1,16 @@
+-- Returns distinct non-null interface and machine values from agent_sessions.
+-- Replaces the client-side approach of fetching all rows to derive filter options.
+create or replace function get_session_filter_options()
+returns table(kind text, value text)
+language sql stable
+as $$
+  select 'interface' as kind, interface as value
+  from agent_sessions
+  where interface is not null
+  group by interface
+  union all
+  select 'machine' as kind, machine as value
+  from agent_sessions
+  where machine is not null
+  group by machine;
+$$;


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- **Replaced the unbounded query** in `fetchFilterOptions` — previously fetched every row from `agent_sessions` just to extract distinct interface/machine values, which scales poorly as the table grows indefinitely with continuous session logging
- **Added a Postgres RPC function** (`get_session_filter_options`) that returns only distinct, non-null values using `GROUP BY` server-side — no more transferring all rows to the client
- **Updated types, tests, and mock setup** to match the new RPC-based approach

## Implementation

The new `get_session_filter_options()` SQL function returns a flat table of `(kind, value)` rows:
- `kind = 'interface'` rows for each distinct interface
- `kind = 'machine'` rows for each distinct machine

This replaces the client-side `new Set(data.map(...))` deduplication with server-side `GROUP BY`, reducing both network payload and client processing.

## Test plan

- [x] All 134 existing tests pass
- [x] TypeScript type checking passes cleanly
- [x] ESLint passes with no warnings
- [ ] Run the migration against the Supabase database (`supabase db push` or apply manually)
- [ ] Verify the Agents page filter dropdowns populate correctly after migration

Resolves [ENG-22](https://linear.app/alecv/issue/ENG-22/optimize-fetchfilteroptions-to-avoid-fetching-all-session-rows)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
