### PR TITLE
Add route-level code splitting with React.lazy (ENG-21)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,16 @@
-import { StrictMode } from 'react'
+/* eslint-disable react-refresh/only-export-components */
+import { lazy, StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Route, Routes } from 'react-router'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 import App from './App'
-import BoardPage from './pages/BoardPage'
-import ToolsPage from './pages/ToolsPage'
-import AgentsPage from './pages/AgentsPage'
-import SettingsPage from './pages/SettingsPage'
 import NotFoundPage from './pages/NotFoundPage'
 import './index.css'
+
+const BoardPage = lazy(() => import('./pages/BoardPage'))
+const ToolsPage = lazy(() => import('./pages/ToolsPage'))
+const AgentsPage = lazy(() => import('./pages/AgentsPage'))
+const SettingsPage = lazy(() => import('./pages/SettingsPage'))
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -16,10 +18,10 @@ createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<App />}>
-            <Route index element={<BoardPage />} />
-            <Route path="tools" element={<ToolsPage />} />
-            <Route path="agents" element={<AgentsPage />} />
-            <Route path="settings" element={<SettingsPage />} />
+            <Route index element={<Suspense><BoardPage /></Suspense>} />
+            <Route path="tools" element={<Suspense><ToolsPage /></Suspense>} />
+            <Route path="agents" element={<Suspense><AgentsPage /></Suspense>} />
+            <Route path="settings" element={<Suspense><SettingsPage /></Suspense>} />
           </Route>
           <Route path="*" element={<NotFoundPage />} />
         </Routes>


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Replace eager imports of `BoardPage`, `ToolsPage`, `AgentsPage`, and `SettingsPage` with `React.lazy()` + `Suspense` for route-level code splitting
- Isolates `@hello-pangea/dnd` (~120KB) to the board route chunk instead of the initial bundle
- Reduces initial JS chunk from **660KB (188KB gz)** → **268KB (78KB gz)** — a ~60% reduction

## Build output (after)

| Chunk | Size | Gzipped |
|-------|------|---------|
| `index` (initial) | 268 KB | 78 KB |
| `supabase` | 107 KB | 28 KB |
| `BoardPage` | 101 KB | 31 KB |
| `ToolsPage` | 24 KB | 7 KB |
| `AgentsPage` | 6 KB | 2 KB |
| `SettingsPage` | 3 KB | 1 KB |

No Vite chunk size warnings.

## Test plan

- [x] Production build succeeds with multiple chunks
- [x] No Vite chunk size warnings
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual: verify each route loads correctly in the browser
- [ ] Manual: verify navigation between routes works without flicker

Closes [ENG-21](https://linear.app/alecv/issue/ENG-21/add-code-splitting-to-reduce-bundle-size)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
