### PR TITLE
Fix act() warnings in component tests (ENG-20)

### DIFF
--- a/src/components/detail/__tests__/CreateProjectDetail.test.tsx
+++ b/src/components/detail/__tests__/CreateProjectDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CreateProjectDetail } from '../CreateProjectDetail';
 
 // ── Store mocks ─────────────────────────────────────────────────
@@ -89,8 +89,10 @@ describe('CreateProjectDetail validation', () => {
     fireEvent.change(nameInput, { target: { value: 'My Project' } });
     fireEvent.click(screen.getByText('Create Project'));
 
-    expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
-    expect(mockCreateProject).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
+      expect(mockCreateProject).toHaveBeenCalled();
+    });
   });
 
   it('allows valid priority values 0–5', async () => {
@@ -102,8 +104,10 @@ describe('CreateProjectDetail validation', () => {
     fireEvent.change(priorityInput, { target: { value: '3' } });
     fireEvent.click(screen.getByText('Create Project'));
 
-    expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
-    expect(mockCreateProject).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText('Priority must be 0–5')).not.toBeInTheDocument();
+      expect(mockCreateProject).toHaveBeenCalled();
+    });
   });
 
   it('sets aria-invalid on name input when error is shown', () => {

--- a/src/components/detail/__tests__/ToolDetail.test.tsx
+++ b/src/components/detail/__tests__/ToolDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ToolDetail } from '../ToolDetail';
 
 // ── Store mocks ─────────────────────────────────────────────────
@@ -71,8 +71,10 @@ describe('ToolDetail validation', () => {
     fireEvent.change(nameInput, { target: { value: 'My Tool' } });
     fireEvent.click(screen.getByLabelText('Save tool'));
 
-    expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
-    expect(mockCreateTool).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
+      expect(mockCreateTool).toHaveBeenCalled();
+    });
   });
 
   it('allows valid URLs', async () => {
@@ -84,8 +86,10 @@ describe('ToolDetail validation', () => {
     fireEvent.change(urlInput, { target: { value: 'https://example.com' } });
     fireEvent.click(screen.getByLabelText('Save tool'));
 
-    expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
-    expect(mockCreateTool).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText('Enter a valid URL (e.g. https://example.com)')).not.toBeInTheDocument();
+      expect(mockCreateTool).toHaveBeenCalled();
+    });
   });
 
   it('clears URL error on typing', () => {


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Wrap post-click assertions in `waitFor()` for 4 tests that trigger async save/create handlers, so React state updates from resolved promises settle inside `act()` boundaries
- Affects `ToolDetail.test.tsx` ("allows empty URL", "allows valid URLs") and `CreateProjectDetail.test.tsx` ("allows empty priority", "allows valid priority values 0–5")
- All 135 tests pass cleanly with zero `act()` warnings

## Root cause

Tests that pass validation fire `handleSave`/`handleCreate`, which `await` mocked store functions (`mockResolvedValue`). The post-await state updates (`setIsSaving(false)`, `selectTool(null)`, `closePanel()`) resolve in microtasks outside React's `act()` boundary. Wrapping assertions in `waitFor()` lets the async updates flush before asserting.

## Test plan

- [x] Run affected test files — all 17 tests pass, zero stderr warnings
- [x] Run full test suite — all 135 tests pass, no regressions
- [x] TypeScript type check passes clean

Resolves [ENG-20](https://linear.app/alecv/issue/ENG-20/fix-act-warnings-in-component-tests)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/muninn/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
